### PR TITLE
fix: use npx instead of bunx for Railway deployment

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -1,11 +1,12 @@
 {
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
-    "builder": "RAILPACK",
+    "builder": "NIXPACKS",
+    "buildCommand": "npm run build",
     "watchPatterns": ["src/**", "index.html", "vite.config.ts"]
   },
   "deploy": {
-    "startCommand": "bunx serve dist -s -l $PORT",
+    "startCommand": "npx serve dist -s -l $PORT",
     "restartPolicyType": "ON_FAILURE"
   }
 }


### PR DESCRIPTION
bunx is not available in Railway's environment, causing `bunx: command not found` errors and serving `text/html` for JS files.

Changed to `npx serve` which works correctly.