### PR TITLE
fix: don't cache hashed JS/CSS in service worker

### DIFF
--- a/src/workers/service-worker.ts
+++ b/src/workers/service-worker.ts
@@ -2,7 +2,8 @@
 
 declare const self: ServiceWorkerGlobalScope;
 
-const CACHE_NAME = 'lisa-v1';
+// Bump this on breaking changes to force cache invalidation
+const CACHE_NAME = 'lisa-v2';
 
 // Install event: cache the app shell
 self.addEventListener('install', (event) => {
@@ -47,6 +48,12 @@ self.addEventListener('fetch', (event) => {
 
   // Skip chrome-extension and other non-http(s) requests
   if (!request.url.startsWith('http')) {
+    return;
+  }
+
+  // Don't cache hashed assets - Vite's content hashing handles browser caching
+  // Caching these causes issues when deployments have interdependent bundles
+  if (request.url.includes('/assets/') && /\.[a-f0-9]{8,}\.(js|css)/.test(request.url)) {
     return;
   }
 


### PR DESCRIPTION
## Problem
When deploying new versions, users see errors like:
```
Failed to fetch dynamically imported module: ItemDetailsModal-BRBVOSO4.js
'text/html' is not a valid JavaScript MIME type
```

## Root Cause
The service worker caches JS bundles that have interdependencies:
1. Old deployment: `ListView-ABC.js` → `ItemDetailsModal-OLD.js`
2. New deployment: `ListView-XYZ.js` → `ItemDetailsModal-NEW.js`
3. User's SW has OLD files cached → tries to load `ItemDetailsModal-OLD.js`
4. That hash doesn't exist in new deployment → 404 → SPA fallback → `text/html`

## Fix
- **Don't cache hashed assets** in the service worker
- Vite's content hashing already handles browser caching via immutable URLs
- Bump cache version to `lisa-v2` to clear old caches

After this, new deployments won't break users with stale caches.