### PR TITLE
feat: Add list templates feature 📁

### DIFF
--- a/src/components/SaveAsTemplateModal.tsx
+++ b/src/components/SaveAsTemplateModal.tsx
@@ -1,0 +1,205 @@
+/**
+ * Modal for saving the current list as a template.
+ */
+
+import { useState, type FormEvent } from "react";
+import { useMutation } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
+import { useCurrentUser } from "../hooks/useCurrentUser";
+import { useFocusTrap } from "../hooks/useFocusTrap";
+import { useSettings } from "../hooks/useSettings";
+
+interface SaveAsTemplateModalProps {
+  listId: Id<"lists">;
+  listName: string;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+export function SaveAsTemplateModal({ listId, listName, onClose, onSuccess }: SaveAsTemplateModalProps) {
+  const { did } = useCurrentUser();
+  const { haptic } = useSettings();
+  const dialogRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
+
+  const [name, setName] = useState(`${listName} Template`);
+  const [description, setDescription] = useState("");
+  const [isPublic, setIsPublic] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const createFromList = useMutation(api.templates.createFromList);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError("Please enter a template name");
+      haptic('error');
+      return;
+    }
+
+    if (!did) {
+      setError("No identity found");
+      haptic('error');
+      return;
+    }
+
+    setError(null);
+    setIsSaving(true);
+    haptic('medium');
+
+    try {
+      await createFromList({
+        listId,
+        templateName: trimmedName,
+        description: description.trim() || undefined,
+        isPublic,
+        userDid: did,
+      });
+
+      haptic('success');
+      setSuccess(true);
+      
+      // Auto-close after short delay
+      setTimeout(() => {
+        onSuccess?.();
+        onClose();
+      }, 1500);
+    } catch (err) {
+      console.error("Failed to save template:", err);
+      setError("Failed to save template. Please try again.");
+      haptic('error');
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="save-template-title"
+        className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-md w-full overflow-hidden animate-slide-up"
+      >
+        {/* Header */}
+        <div className="px-6 pt-6 pb-4">
+          <div className="flex items-center gap-3 mb-2">
+            <span className="text-3xl">📁</span>
+            <h2 id="save-template-title" className="text-xl font-bold text-gray-900 dark:text-gray-100">
+              Save as Template
+            </h2>
+          </div>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Save this list structure to reuse it later. Only unchecked items will be included.
+          </p>
+        </div>
+
+        {success ? (
+          <div className="px-6 pb-6">
+            <div className="flex flex-col items-center py-8">
+              <div className="w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mb-4">
+                <svg className="w-8 h-8 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                </svg>
+              </div>
+              <p className="text-lg font-medium text-gray-900 dark:text-gray-100">Template Saved!</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                You can find it in Templates page
+              </p>
+            </div>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="px-6 pb-6">
+            <label htmlFor="templateName" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+              Template name
+            </label>
+            <input
+              id="templateName"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g., Weekly Groceries Template"
+              className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:border-amber-500 dark:focus:border-amber-500 focus:ring-4 focus:ring-amber-500/10 transition-all disabled:opacity-50"
+              disabled={isSaving}
+              autoFocus
+            />
+
+            <label htmlFor="templateDescription" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 mt-4">
+              Description (optional)
+            </label>
+            <textarea
+              id="templateDescription"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="What is this template for?"
+              rows={2}
+              className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:border-amber-500 dark:focus:border-amber-500 focus:ring-4 focus:ring-amber-500/10 transition-all disabled:opacity-50 resize-none"
+              disabled={isSaving}
+            />
+
+            <div className="mt-4">
+              <label className="flex items-center gap-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={isPublic}
+                  onChange={(e) => setIsPublic(e.target.checked)}
+                  disabled={isSaving}
+                  className="w-5 h-5 rounded border-gray-300 dark:border-gray-600 text-amber-500 focus:ring-amber-500 dark:bg-gray-700"
+                />
+                <span className="text-sm text-gray-700 dark:text-gray-300">
+                  Make public (others can use this template)
+                </span>
+              </label>
+            </div>
+
+            {error && (
+              <div className="mt-4 px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-red-700 dark:text-red-400 text-sm flex items-center gap-2">
+                <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                {error}
+              </div>
+            )}
+
+            <div className="mt-6 flex gap-3">
+              <button
+                type="button"
+                onClick={() => {
+                  haptic('light');
+                  onClose();
+                }}
+                disabled={isSaving}
+                className="flex-1 px-4 py-3 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-xl font-medium hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={isSaving || !name.trim()}
+                className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
+              >
+                {isSaving ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                    </svg>
+                    Saving...
+                  </span>
+                ) : (
+                  "Save Template"
+                )}
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default SaveAsTemplateModal;

--- a/src/components/TemplatePickerModal.tsx
+++ b/src/components/TemplatePickerModal.tsx
@@ -1,0 +1,324 @@
+/**
+ * Modal for selecting a template when creating a new list.
+ * Shows built-in templates and user's saved templates.
+ */
+
+import { useState } from "react";
+import { useQuery, useMutation } from "convex/react";
+import { useNavigate } from "react-router-dom";
+import { api } from "../../convex/_generated/api";
+import type { Id } from "../../convex/_generated/dataModel";
+import { useCurrentUser } from "../hooks/useCurrentUser";
+import { useFocusTrap } from "../hooks/useFocusTrap";
+import { useSettings } from "../hooks/useSettings";
+import { createListAsset } from "../lib/originals";
+import { BUILTIN_TEMPLATES, type BuiltinTemplate } from "../lib/builtinTemplates";
+
+interface TemplatePickerModalProps {
+  onClose: () => void;
+  onCreateBlank: () => void;
+}
+
+export function TemplatePickerModal({ onClose, onCreateBlank }: TemplatePickerModalProps) {
+  const { did } = useCurrentUser();
+  const navigate = useNavigate();
+  const { haptic } = useSettings();
+  const dialogRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
+
+  const [selectedTemplate, setSelectedTemplate] = useState<BuiltinTemplate | null>(null);
+  const [customName, setCustomName] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch user's saved templates
+  const userTemplates = useQuery(
+    api.templates.getUserTemplates,
+    did ? { userDid: did } : "skip"
+  );
+
+  // Mutations
+  const createList = useMutation(api.lists.createList);
+  const addItem = useMutation(api.items.addItem);
+  const createListFromTemplate = useMutation(api.templates.createListFromTemplate);
+
+  const handleSelectBuiltin = (template: BuiltinTemplate) => {
+    haptic('light');
+    setSelectedTemplate(template);
+    setCustomName(template.name);
+  };
+
+  const handleCreateFromBuiltin = async () => {
+    if (!selectedTemplate || !did) return;
+
+    const listName = customName.trim() || selectedTemplate.name;
+    setError(null);
+    setIsCreating(true);
+    haptic('medium');
+
+    try {
+      // Create the list
+      const listAsset = await createListAsset(listName, did);
+      const listId = await createList({
+        assetDid: listAsset.assetDid,
+        name: listName,
+        ownerDid: did,
+        createdAt: Date.now(),
+      });
+
+      // Add items from template
+      const now = Date.now();
+      for (const item of selectedTemplate.items) {
+        await addItem({
+          listId,
+          name: item.name,
+          createdByDid: did,
+          createdAt: now,
+          priority: item.priority,
+          description: item.description,
+        });
+      }
+
+      haptic('success');
+      navigate(`/list/${listId}`);
+    } catch (err) {
+      console.error("Failed to create list from template:", err);
+      setError("Failed to create list. Please try again.");
+      haptic('error');
+      setIsCreating(false);
+    }
+  };
+
+  const handleCreateFromSaved = async (templateId: Id<"listTemplates">, templateName: string) => {
+    if (!did) return;
+
+    setError(null);
+    setIsCreating(true);
+    haptic('medium');
+
+    try {
+      const listId = await createListFromTemplate({
+        templateId,
+        listName: templateName,
+        userDid: did,
+      });
+
+      haptic('success');
+      navigate(`/list/${listId}`);
+    } catch (err) {
+      console.error("Failed to create list from saved template:", err);
+      setError("Failed to create list. Please try again.");
+      haptic('error');
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="template-picker-title"
+        className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-lg w-full max-h-[85vh] overflow-hidden animate-slide-up flex flex-col"
+      >
+        {/* Header */}
+        <div className="px-6 pt-6 pb-4 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center gap-3 mb-2">
+            <span className="text-3xl">📁</span>
+            <h2 id="template-picker-title" className="text-xl font-bold text-gray-900 dark:text-gray-100">
+              {selectedTemplate ? "Customize Template" : "Choose a Template"}
+            </h2>
+          </div>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {selectedTemplate 
+              ? "Customize the name or create with defaults"
+              : "Start with a template or create a blank list"
+            }
+          </p>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-6">
+          {selectedTemplate ? (
+            /* Template customization view */
+            <div className="space-y-4">
+              <button
+                onClick={() => {
+                  haptic('light');
+                  setSelectedTemplate(null);
+                }}
+                className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+                </svg>
+                Back to templates
+              </button>
+
+              <div className="bg-amber-50 dark:bg-amber-900/20 rounded-xl p-4 flex items-start gap-3">
+                <span className="text-2xl">{selectedTemplate.emoji}</span>
+                <div>
+                  <p className="font-medium text-gray-900 dark:text-gray-100">{selectedTemplate.name}</p>
+                  <p className="text-sm text-gray-600 dark:text-gray-400">{selectedTemplate.items.length} items</p>
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="listName" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  List name
+                </label>
+                <input
+                  id="listName"
+                  type="text"
+                  value={customName}
+                  onChange={(e) => setCustomName(e.target.value)}
+                  placeholder={selectedTemplate.name}
+                  className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:border-amber-500 dark:focus:border-amber-500 focus:ring-4 focus:ring-amber-500/10 transition-all disabled:opacity-50"
+                  disabled={isCreating}
+                />
+              </div>
+
+              <div>
+                <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                  Items included:
+                </p>
+                <ul className="bg-gray-50 dark:bg-gray-900 rounded-xl p-3 max-h-40 overflow-y-auto space-y-1">
+                  {selectedTemplate.items.map((item, idx) => (
+                    <li key={idx} className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                      <span className="w-4 h-4 rounded border border-gray-300 dark:border-gray-600" />
+                      <span>{item.name}</span>
+                      {item.priority && (
+                        <span className={`text-xs px-1.5 py-0.5 rounded ${
+                          item.priority === 'high' ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' :
+                          item.priority === 'medium' ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400' :
+                          'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+                        }`}>
+                          {item.priority}
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {error && (
+                <div className="px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-red-700 dark:text-red-400 text-sm flex items-center gap-2">
+                  <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  {error}
+                </div>
+              )}
+            </div>
+          ) : (
+            /* Template selection view */
+            <div className="space-y-6">
+              {/* Blank list option */}
+              <button
+                onClick={() => {
+                  haptic('light');
+                  onCreateBlank();
+                }}
+                className="w-full flex items-center gap-4 p-4 bg-gradient-to-r from-amber-50 to-orange-50 dark:from-amber-900/20 dark:to-orange-900/20 border-2 border-dashed border-amber-300 dark:border-amber-700 rounded-xl hover:border-amber-400 dark:hover:border-amber-600 transition-colors text-left"
+              >
+                <span className="text-2xl">✨</span>
+                <div>
+                  <p className="font-medium text-gray-900 dark:text-gray-100">Blank List</p>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Start from scratch</p>
+                </div>
+              </button>
+
+              {/* Built-in templates */}
+              <div>
+                <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+                  Quick Start Templates
+                </h3>
+                <div className="grid gap-3">
+                  {BUILTIN_TEMPLATES.map((template) => (
+                    <button
+                      key={template.id}
+                      onClick={() => handleSelectBuiltin(template)}
+                      className="w-full flex items-center gap-4 p-4 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-xl hover:border-amber-400 dark:hover:border-amber-500 hover:shadow-md transition-all text-left"
+                    >
+                      <span className="text-2xl">{template.emoji}</span>
+                      <div className="flex-1 min-w-0">
+                        <p className="font-medium text-gray-900 dark:text-gray-100">{template.name}</p>
+                        <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{template.description}</p>
+                      </div>
+                      <span className="text-xs text-gray-400 dark:text-gray-500">{template.items.length} items</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* User's saved templates */}
+              {userTemplates && userTemplates.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+                    My Templates
+                  </h3>
+                  <div className="grid gap-3">
+                    {userTemplates.map((template) => (
+                      <button
+                        key={template._id}
+                        onClick={() => handleCreateFromSaved(template._id, template.name)}
+                        disabled={isCreating}
+                        className="w-full flex items-center gap-4 p-4 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-xl hover:border-amber-400 dark:hover:border-amber-500 hover:shadow-md transition-all text-left disabled:opacity-50"
+                      >
+                        <span className="text-2xl">📄</span>
+                        <div className="flex-1 min-w-0">
+                          <p className="font-medium text-gray-900 dark:text-gray-100">{template.name}</p>
+                          {template.description && (
+                            <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{template.description}</p>
+                          )}
+                        </div>
+                        <span className="text-xs text-gray-400 dark:text-gray-500">{template.items.length} items</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              haptic('light');
+              onClose();
+            }}
+            disabled={isCreating}
+            className="flex-1 px-4 py-3 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-xl font-medium hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors"
+          >
+            Cancel
+          </button>
+          {selectedTemplate && (
+            <button
+              type="button"
+              onClick={handleCreateFromBuiltin}
+              disabled={isCreating}
+              className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
+            >
+              {isCreating ? (
+                <span className="flex items-center justify-center gap-2">
+                  <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                  </svg>
+                  Creating...
+                </span>
+              ) : (
+                "Create List"
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TemplatePickerModal;

--- a/src/lib/builtinTemplates.ts
+++ b/src/lib/builtinTemplates.ts
@@ -1,0 +1,130 @@
+/**
+ * Built-in list templates that are always available.
+ * Users can also create their own templates from existing lists.
+ */
+
+export interface BuiltinTemplateItem {
+  name: string;
+  description?: string;
+  priority?: "high" | "medium" | "low";
+  order: number;
+}
+
+export interface BuiltinTemplate {
+  id: string;
+  name: string;
+  emoji: string;
+  description: string;
+  items: BuiltinTemplateItem[];
+}
+
+export const BUILTIN_TEMPLATES: BuiltinTemplate[] = [
+  {
+    id: "grocery",
+    name: "Grocery List",
+    emoji: "🛒",
+    description: "Common grocery items to get you started",
+    items: [
+      { name: "Milk", order: 0 },
+      { name: "Eggs", order: 1 },
+      { name: "Bread", order: 2 },
+      { name: "Butter", order: 3 },
+      { name: "Cheese", order: 4 },
+      { name: "Fruits", order: 5 },
+      { name: "Vegetables", order: 6 },
+      { name: "Chicken/Meat", order: 7 },
+      { name: "Rice/Pasta", order: 8 },
+      { name: "Snacks", order: 9 },
+    ],
+  },
+  {
+    id: "packing",
+    name: "Packing Checklist",
+    emoji: "🧳",
+    description: "Essential items for your next trip",
+    items: [
+      { name: "Passport/ID", priority: "high", order: 0 },
+      { name: "Phone charger", priority: "high", order: 1 },
+      { name: "Toiletries", order: 2 },
+      { name: "Medications", priority: "high", order: 3 },
+      { name: "Clothes (underwear, socks)", order: 4 },
+      { name: "Outerwear/jacket", order: 5 },
+      { name: "Shoes", order: 6 },
+      { name: "Laptop/tablet", order: 7 },
+      { name: "Headphones", order: 8 },
+      { name: "Sunglasses", order: 9 },
+      { name: "Wallet/cards", priority: "high", order: 10 },
+      { name: "Travel pillow", order: 11 },
+    ],
+  },
+  {
+    id: "weekly-tasks",
+    name: "Weekly Tasks",
+    emoji: "📅",
+    description: "Common weekly chores and activities",
+    items: [
+      { name: "Grocery shopping", order: 0 },
+      { name: "Laundry", order: 1 },
+      { name: "Clean bathroom", order: 2 },
+      { name: "Vacuum/mop floors", order: 3 },
+      { name: "Take out trash", order: 4 },
+      { name: "Meal prep", order: 5 },
+      { name: "Exercise (3x)", priority: "medium", order: 6 },
+      { name: "Review budget", order: 7 },
+      { name: "Call family/friends", order: 8 },
+    ],
+  },
+  {
+    id: "project-kickoff",
+    name: "Project Kickoff",
+    emoji: "🚀",
+    description: "Get your new project started right",
+    items: [
+      { name: "Define project goals", priority: "high", order: 0 },
+      { name: "Identify stakeholders", priority: "high", order: 1 },
+      { name: "Set timeline/milestones", priority: "high", order: 2 },
+      { name: "Create project repo/workspace", order: 3 },
+      { name: "Write initial documentation", order: 4 },
+      { name: "Set up communication channel", order: 5 },
+      { name: "Schedule kickoff meeting", order: 6 },
+      { name: "Assign initial tasks", order: 7 },
+      { name: "Define success metrics", priority: "medium", order: 8 },
+    ],
+  },
+  {
+    id: "moving",
+    name: "Moving Checklist",
+    emoji: "📦",
+    description: "Everything you need for a smooth move",
+    items: [
+      { name: "Update address (mail, subscriptions)", priority: "high", order: 0 },
+      { name: "Transfer utilities", priority: "high", order: 1 },
+      { name: "Pack room by room", order: 2 },
+      { name: "Label all boxes", order: 3 },
+      { name: "Hire movers or rent truck", priority: "high", order: 4 },
+      { name: "Clean old place", order: 5 },
+      { name: "Get new keys", priority: "high", order: 6 },
+      { name: "Set up internet/cable", order: 7 },
+      { name: "Update driver's license", order: 8 },
+      { name: "Notify bank/employers", order: 9 },
+    ],
+  },
+  {
+    id: "party-planning",
+    name: "Party Planning",
+    emoji: "🎉",
+    description: "Plan the perfect celebration",
+    items: [
+      { name: "Set date and time", priority: "high", order: 0 },
+      { name: "Create guest list", priority: "high", order: 1 },
+      { name: "Send invitations", order: 2 },
+      { name: "Plan menu/food", order: 3 },
+      { name: "Order cake", order: 4 },
+      { name: "Buy drinks", order: 5 },
+      { name: "Get decorations", order: 6 },
+      { name: "Create playlist", order: 7 },
+      { name: "Plan activities/games", order: 8 },
+      { name: "Set up day before", order: 9 },
+    ],
+  },
+];

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,6 +16,7 @@ import { useOffline } from "../hooks/useOffline";
 import { useSettings } from "../hooks/useSettings";
 import { ListCard } from "../components/ListCard";
 import { CreateListModal } from "../components/CreateListModal";
+import { TemplatePickerModal } from "../components/TemplatePickerModal";
 import { CategoryHeader } from "../components/lists/CategoryHeader";
 import { CategoryManager } from "../components/lists/CategoryManager";
 import { SearchInput } from "../components/ui/SearchInput";
@@ -33,6 +34,7 @@ export function Home() {
   const [searchParams] = useSearchParams();
   
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+  const [isTemplatePickerOpen, setIsTemplatePickerOpen] = useState(false);
   const [isCategoryManagerOpen, setIsCategoryManagerOpen] = useState(false);
   const [cachedLists, setCachedLists] = useState<OfflineList[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
@@ -40,7 +42,7 @@ export function Home() {
   // Check for action param (e.g., from PWA shortcut)
   useEffect(() => {
     if (searchParams.get('action') === 'new') {
-      setIsCreateModalOpen(true);
+      setIsTemplatePickerOpen(true);
     }
   }, [searchParams]);
 
@@ -175,6 +177,11 @@ export function Home() {
 
   const handleOpenCreate = () => {
     haptic('light');
+    setIsTemplatePickerOpen(true);
+  };
+
+  const handleCreateBlank = () => {
+    setIsTemplatePickerOpen(false);
     setIsCreateModalOpen(true);
   };
 
@@ -352,6 +359,13 @@ export function Home() {
       )}
 
       {/* Modals */}
+      {isTemplatePickerOpen && (
+        <TemplatePickerModal 
+          onClose={() => setIsTemplatePickerOpen(false)}
+          onCreateBlank={handleCreateBlank}
+        />
+      )}
+
       {isCreateModalOpen && (
         <CreateListModal onClose={() => setIsCreateModalOpen(false)} />
       )}

--- a/src/pages/ListView.tsx
+++ b/src/pages/ListView.tsx
@@ -31,6 +31,7 @@ const DeleteListDialog = lazy(() => import("../components/DeleteListDialog").the
 const ShareModal = lazy(() => import("../components/ShareModal").then(m => ({ default: m.ShareModal })));
 const PublishModal = lazy(() => import("../components/publish/PublishModal").then(m => ({ default: m.PublishModal })));
 const ItemDetailsModal = lazy(() => import("../components/ItemDetailsModal").then(m => ({ default: m.ItemDetailsModal })));
+const SaveAsTemplateModal = lazy(() => import("../components/SaveAsTemplateModal").then(m => ({ default: m.SaveAsTemplateModal })));
 
 type ViewMode = "list" | "calendar";
 
@@ -44,6 +45,7 @@ export function ListView() {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
   const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
+  const [isSaveTemplateModalOpen, setIsSaveTemplateModalOpen] = useState(false);
   const [showCollaborators, setShowCollaborators] = useState(false);
   const [draggedItemId, setDraggedItemId] = useState<Id<"items"> | null>(null);
   const [dragOverItemId, setDragOverItemId] = useState<Id<"items"> | null>(null);
@@ -353,6 +355,25 @@ export function ListView() {
               🔗 Share
             </button>
           )}
+          {/* Save as Template button */}
+          {canUserEdit && (
+            <button
+              onClick={() => {
+                haptic('light');
+                setIsSaveTemplateModalOpen(true);
+              }}
+              disabled={!isOnline}
+              title={!isOnline ? "Available when online" : "Save as template"}
+              className={`p-2.5 text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/20 rounded-xl hover:bg-amber-100 dark:hover:bg-amber-900/40 transition-colors ${
+                !isOnline ? "opacity-50 cursor-not-allowed" : ""
+              }`}
+              aria-label="Save as template"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7v8a2 2 0 002 2h6M8 7V5a2 2 0 012-2h4.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V15a2 2 0 01-2 2h-2M8 7H6a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2v-2" />
+              </svg>
+            </button>
+          )}
           {canUserDelete && (
             <button
               onClick={() => {
@@ -496,6 +517,14 @@ export function ListView() {
 
         {isPublishModalOpen && (
           <PublishModal list={list} onClose={() => setIsPublishModalOpen(false)} />
+        )}
+
+        {isSaveTemplateModalOpen && (
+          <SaveAsTemplateModal
+            listId={listId}
+            listName={list.name}
+            onClose={() => setIsSaveTemplateModalOpen(false)}
+          />
         )}
 
         {selectedCalendarItem && (


### PR DESCRIPTION
## Summary
Add the ability to create lists from pre-defined templates, making it faster to get started with common list types.

## Features Added

### 1. Template Picker Modal
- Shows when clicking 'New List' button
- Option to create blank list or choose from templates
- Displays both built-in and user-saved templates

### 2. Built-in Templates (6 templates)
- 🛒 **Grocery List** - Common grocery items
- 🧳 **Packing Checklist** - Travel essentials with priority flags
- 📅 **Weekly Tasks** - Common weekly chores
- 🚀 **Project Kickoff** - Get projects started right
- 📦 **Moving Checklist** - Everything for a smooth move
- 🎉 **Party Planning** - Plan celebrations

### 3. Save as Template
- New button in ListView header (copy/template icon)
- Saves current list's unchecked items as a reusable template
- Option to make templates public
- Add name and description

### 4. Templates Page Improvements
- Now shows built-in templates section
- Connected to actual Convex API
- 'Use' buttons actually work now

## Screenshots
The template picker appears when creating a new list, showing built-in options and any saved templates.

## Technical Details
- Templates pre-populate with items including priorities
- Uses existing Convex templates API
- Lazy-loaded modals for bundle optimization
- Build passes ✅

Closes: List templates feature request