### PR TITLE
⌨️ Keyboard shortcuts for power users

### DIFF
--- a/src/components/AddItemInput.tsx
+++ b/src/components/AddItemInput.tsx
@@ -3,7 +3,7 @@
  * Features improved design, dark mode, and haptic feedback.
  */
 
-import { useState, useRef, type FormEvent } from "react";
+import { useState, useRef, type FormEvent, forwardRef, useImperativeHandle } from "react";
 import { useCurrentUser } from "../hooks/useCurrentUser";
 import { useSettings } from "../hooks/useSettings";
 
@@ -17,10 +17,13 @@ interface AddItemInputProps {
   }) => Promise<void>;
 }
 
-export function AddItemInput({ onAddItem }: AddItemInputProps) {
+export const AddItemInput = forwardRef<HTMLInputElement, AddItemInputProps>(function AddItemInput({ onAddItem }, ref) {
   const { did, legacyDid } = useCurrentUser();
   const { haptic } = useSettings();
   const inputRef = useRef<HTMLInputElement>(null);
+  
+  // Expose the input ref to parent components
+  useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
 
   const [name, setName] = useState("");
   const [isAdding, setIsAdding] = useState(false);
@@ -96,4 +99,4 @@ export function AddItemInput({ onAddItem }: AddItemInputProps) {
       </button>
     </form>
   );
-}
+});

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -25,6 +25,7 @@ interface ListItemProps {
   canEdit?: boolean;
   isDragging?: boolean;
   isDragOver?: boolean;
+  isFocused?: boolean;
   onDragStart?: () => void;
   onDragOver?: (e: React.DragEvent) => void;
   onDragEnd?: () => void;
@@ -45,6 +46,7 @@ export function ListItem({
   canEdit: canUserEdit = true,
   isDragging = false,
   isDragOver = false,
+  isFocused = false,
   onDragStart,
   onDragOver,
   onDragEnd,
@@ -183,6 +185,10 @@ export function ListItem({
       } ${
         isSelected
           ? "bg-amber-50 dark:bg-amber-900/30 ring-2 ring-amber-400 dark:ring-amber-600"
+          : ""
+      } ${
+        isFocused && !isSelected
+          ? "bg-blue-50 dark:bg-blue-900/20 ring-2 ring-blue-400 dark:ring-blue-600"
           : ""
       } ${
         isSelectMode


### PR DESCRIPTION
## Summary
Adds keyboard shortcuts for navigating and acting on list items, enabling power users to work faster without using a mouse.

## Features
- **n** or **/**: Focus add item input
- **j/k** or **↑/↓**: Navigate up/down items  
- **x** or **space**: Toggle check on focused item
- **e** or **Enter**: Edit focused item
- **d**, **Delete**, or **Backspace**: Delete focused item
- **Escape**: Clear focus / close modals
- **?**: Show keyboard shortcuts help modal

## Implementation
- Visual focus indicator (blue ring) on keyboard-navigated items
- Help modal showing all shortcuts (press ? or click ⌨️ button)
- Leverages existing `useKeyboardShortcuts` hook
- Shortcuts disabled when typing in inputs (only Escape works)
- Focus automatically adjusts when items are deleted

## Screenshots
The focused item shows with a blue ring, and pressing ? shows the shortcuts modal.

## Testing
- Build passes ✅
- All keyboard shortcuts work as expected
- Focus state properly tracks items