### PR TITLE
fix: TypeScript build error in SubItems - cast parentId properly

### DIFF
--- a/src/components/SubItems.tsx
+++ b/src/components/SubItems.tsx
@@ -56,6 +56,9 @@ export function SubItems({
     e.preventDefault();
     if (!newItemName.trim() || !canEdit || isAdding) return;
     
+    // Can't add sub-items to a temp parent (not yet persisted)
+    if (isTemp) return;
+    
     haptic("medium");
     setIsAdding(true);
 
@@ -66,7 +69,7 @@ export function SubItems({
         createdByDid: userDid,
         legacyDid,
         createdAt: Date.now(),
-        parentId,
+        parentId: parentId as Id<"items">,
       });
       haptic("success");
       setNewItemName("");


### PR DESCRIPTION
## Summary
Fixes the TypeScript build error on main:
```
src/components/SubItems.tsx(69,9): error TS2322: Type 'string | Id<"items">" is not assignable to type 'Id<"items"> | undefined'.
  Type 'string' is not assignable to type 'Id<"items">'.
```

## Changes
- Added early return guard when `parentId` is a temp ID (can't add sub-items to a non-persisted parent anyway)
- Cast `parentId as Id<"items">` in the `addItem` call since we've verified it's not a temp ID

## Testing
- `bun run build` passes ✅