### PR TITLE
feat: Replace modals with slide-up panels for better mobile UX

### DIFF
--- a/src/components/CreateListModal.tsx
+++ b/src/components/CreateListModal.tsx
@@ -1,5 +1,6 @@
 /**
- * Modal for creating a new list.
+ * Panel for creating a new list.
+ * Uses Panel component for slide-up drawer experience.
  * Features improved design and dark mode support.
  */
 
@@ -9,10 +10,10 @@ import { useNavigate } from "react-router-dom";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
 import { useCurrentUser } from "../hooks/useCurrentUser";
-import { useFocusTrap } from "../hooks/useFocusTrap";
 import { useSettings } from "../hooks/useSettings";
 import { createListAsset } from "../lib/originals";
 import { CategorySelector } from "./lists/CategorySelector";
+import { Panel } from "./ui/Panel";
 
 interface CreateListModalProps {
   onClose: () => void;
@@ -23,7 +24,6 @@ export function CreateListModal({ onClose }: CreateListModalProps) {
   const navigate = useNavigate();
   const { haptic } = useSettings();
   const createList = useMutation(api.lists.createList);
-  const dialogRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
 
   const [name, setName] = useState("");
   const [categoryId, setCategoryId] = useState<Id<"categories"> | undefined>(undefined);
@@ -71,30 +71,79 @@ export function CreateListModal({ onClose }: CreateListModalProps) {
     }
   };
 
-  return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="create-list-dialog-title"
-        className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-md w-full overflow-hidden animate-slide-up"
-      >
-        {/* Header */}
-        <div className="px-6 pt-6 pb-4">
-          <div className="flex items-center gap-3 mb-2">
-            <span className="text-3xl">✨</span>
-            <h2 id="create-list-dialog-title" className="text-xl font-bold text-gray-900 dark:text-gray-100">
-              Create New List
-            </h2>
-          </div>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            Give your list a name and optionally assign it to a category.
+  const header = (
+    <>
+      <div className="flex items-center gap-3">
+        <span className="text-2xl">✨</span>
+        <div>
+          <h2 id="create-list-dialog-title" className="text-lg font-bold text-gray-900 dark:text-gray-100">
+            Create New List
+          </h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Give your list a name
           </p>
         </div>
+      </div>
+      <button
+        onClick={() => {
+          haptic('light');
+          onClose();
+        }}
+        className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        aria-label="Close"
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </>
+  );
 
-        {/* Form */}
-        <form onSubmit={handleSubmit} className="px-6 pb-6">
+  const footer = (
+    <div className="px-5 py-4 flex gap-3">
+      <button
+        type="button"
+        onClick={() => {
+          haptic('light');
+          onClose();
+        }}
+        disabled={isCreating}
+        className="flex-1 px-4 py-3 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-xl font-medium hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors"
+      >
+        Cancel
+      </button>
+      <button
+        type="submit"
+        form="create-list-form"
+        disabled={isCreating || !name.trim()}
+        className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
+      >
+        {isCreating ? (
+          <span className="flex items-center justify-center gap-2">
+            <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+            </svg>
+            Creating...
+          </span>
+        ) : (
+          "Create List"
+        )}
+      </button>
+    </div>
+  );
+
+  return (
+    <Panel
+      isOpen={true}
+      onClose={onClose}
+      header={header}
+      footer={footer}
+      ariaLabelledBy="create-list-dialog-title"
+    >
+      {/* Form */}
+      <form id="create-list-form" onSubmit={handleSubmit} className="p-5 space-y-4">
+        <div>
           <label htmlFor="listName" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
             List name
           </label>
@@ -108,56 +157,23 @@ export function CreateListModal({ onClose }: CreateListModalProps) {
             disabled={isCreating}
             autoFocus
           />
+        </div>
 
-          <div className="mt-4">
-            <CategorySelector
-              value={categoryId}
-              onChange={setCategoryId}
-              disabled={isCreating}
-            />
+        <CategorySelector
+          value={categoryId}
+          onChange={setCategoryId}
+          disabled={isCreating}
+        />
+
+        {error && (
+          <div className="px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-red-700 dark:text-red-400 text-sm flex items-center gap-2">
+            <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            {error}
           </div>
-
-          {error && (
-            <div className="mt-4 px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-red-700 dark:text-red-400 text-sm flex items-center gap-2">
-              <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-              {error}
-            </div>
-          )}
-
-          <div className="mt-6 flex gap-3">
-            <button
-              type="button"
-              onClick={() => {
-                haptic('light');
-                onClose();
-              }}
-              disabled={isCreating}
-              className="flex-1 px-4 py-3 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-xl font-medium hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={isCreating || !name.trim()}
-              className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
-            >
-              {isCreating ? (
-                <span className="flex items-center justify-center gap-2">
-                  <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                  </svg>
-                  Creating...
-                </span>
-              ) : (
-                "Create List"
-              )}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+        )}
+      </form>
+    </Panel>
   );
 }

--- a/src/components/SaveAsTemplateModal.tsx
+++ b/src/components/SaveAsTemplateModal.tsx
@@ -1,5 +1,6 @@
 /**
- * Modal for saving the current list as a template.
+ * Panel for saving the current list as a template.
+ * Uses Panel component for slide-up drawer experience.
  */
 
 import { useState, type FormEvent } from "react";
@@ -7,8 +8,8 @@ import { useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
 import { useCurrentUser } from "../hooks/useCurrentUser";
-import { useFocusTrap } from "../hooks/useFocusTrap";
 import { useSettings } from "../hooks/useSettings";
+import { Panel } from "./ui/Panel";
 
 interface SaveAsTemplateModalProps {
   listId: Id<"lists">;
@@ -20,7 +21,6 @@ interface SaveAsTemplateModalProps {
 export function SaveAsTemplateModal({ listId, listName, onClose, onSuccess }: SaveAsTemplateModalProps) {
   const { did } = useCurrentUser();
   const { haptic } = useSettings();
-  const dialogRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
 
   const [name, setName] = useState(`${listName} Template`);
   const [description, setDescription] = useState("");
@@ -76,44 +76,93 @@ export function SaveAsTemplateModal({ listId, listName, onClose, onSuccess }: Sa
     }
   };
 
-  return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="save-template-title"
-        className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-md w-full overflow-hidden animate-slide-up"
-      >
-        {/* Header */}
-        <div className="px-6 pt-6 pb-4">
-          <div className="flex items-center gap-3 mb-2">
-            <span className="text-3xl">📁</span>
-            <h2 id="save-template-title" className="text-xl font-bold text-gray-900 dark:text-gray-100">
-              Save as Template
-            </h2>
-          </div>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            Save this list structure to reuse it later. Only unchecked items will be included.
+  const header = (
+    <>
+      <div className="flex items-center gap-3">
+        <span className="text-2xl">📁</span>
+        <div>
+          <h2 id="save-template-title" className="text-lg font-bold text-gray-900 dark:text-gray-100">
+            Save as Template
+          </h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Reuse this list structure later
           </p>
         </div>
+      </div>
+      <button
+        onClick={() => {
+          haptic('light');
+          onClose();
+        }}
+        className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        aria-label="Close"
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </>
+  );
 
-        {success ? (
-          <div className="px-6 pb-6">
-            <div className="flex flex-col items-center py-8">
-              <div className="w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mb-4">
-                <svg className="w-8 h-8 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                </svg>
-              </div>
-              <p className="text-lg font-medium text-gray-900 dark:text-gray-100">Template Saved!</p>
-              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                You can find it in Templates page
-              </p>
-            </div>
-          </div>
+  const footer = !success ? (
+    <div className="px-5 py-4 flex gap-3">
+      <button
+        type="button"
+        onClick={() => {
+          haptic('light');
+          onClose();
+        }}
+        disabled={isSaving}
+        className="flex-1 px-4 py-3 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-xl font-medium hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors"
+      >
+        Cancel
+      </button>
+      <button
+        type="submit"
+        form="save-template-form"
+        disabled={isSaving || !name.trim()}
+        className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
+      >
+        {isSaving ? (
+          <span className="flex items-center justify-center gap-2">
+            <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+            </svg>
+            Saving...
+          </span>
         ) : (
-          <form onSubmit={handleSubmit} className="px-6 pb-6">
+          "Save Template"
+        )}
+      </button>
+    </div>
+  ) : undefined;
+
+  return (
+    <Panel
+      isOpen={true}
+      onClose={onClose}
+      header={header}
+      footer={footer}
+      ariaLabelledBy="save-template-title"
+    >
+      {success ? (
+        <div className="p-5">
+          <div className="flex flex-col items-center py-8">
+            <div className="w-16 h-16 bg-green-100 dark:bg-green-900/30 rounded-full flex items-center justify-center mb-4">
+              <svg className="w-8 h-8 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <p className="text-lg font-medium text-gray-900 dark:text-gray-100">Template Saved!</p>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              You can find it in Templates page
+            </p>
+          </div>
+        </div>
+      ) : (
+        <form id="save-template-form" onSubmit={handleSubmit} className="p-5 space-y-4">
+          <div>
             <label htmlFor="templateName" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               Template name
             </label>
@@ -127,8 +176,10 @@ export function SaveAsTemplateModal({ listId, listName, onClose, onSuccess }: Sa
               disabled={isSaving}
               autoFocus
             />
+          </div>
 
-            <label htmlFor="templateDescription" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2 mt-4">
+          <div>
+            <label htmlFor="templateDescription" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
               Description (optional)
             </label>
             <textarea
@@ -140,65 +191,38 @@ export function SaveAsTemplateModal({ listId, listName, onClose, onSuccess }: Sa
               className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:border-amber-500 dark:focus:border-amber-500 focus:ring-4 focus:ring-amber-500/10 transition-all disabled:opacity-50 resize-none"
               disabled={isSaving}
             />
+          </div>
 
-            <div className="mt-4">
-              <label className="flex items-center gap-3 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={isPublic}
-                  onChange={(e) => setIsPublic(e.target.checked)}
-                  disabled={isSaving}
-                  className="w-5 h-5 rounded border-gray-300 dark:border-gray-600 text-amber-500 focus:ring-amber-500 dark:bg-gray-700"
-                />
-                <span className="text-sm text-gray-700 dark:text-gray-300">
-                  Make public (others can use this template)
-                </span>
-              </label>
-            </div>
-
-            {error && (
-              <div className="mt-4 px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-red-700 dark:text-red-400 text-sm flex items-center gap-2">
-                <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                </svg>
-                {error}
-              </div>
-            )}
-
-            <div className="mt-6 flex gap-3">
-              <button
-                type="button"
-                onClick={() => {
-                  haptic('light');
-                  onClose();
-                }}
+          <div>
+            <label className="flex items-center gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={isPublic}
+                onChange={(e) => setIsPublic(e.target.checked)}
                 disabled={isSaving}
-                className="flex-1 px-4 py-3 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-xl font-medium hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={isSaving || !name.trim()}
-                className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
-              >
-                {isSaving ? (
-                  <span className="flex items-center justify-center gap-2">
-                    <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
-                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                    </svg>
-                    Saving...
-                  </span>
-                ) : (
-                  "Save Template"
-                )}
-              </button>
+                className="w-5 h-5 rounded border-gray-300 dark:border-gray-600 text-amber-500 focus:ring-amber-500 dark:bg-gray-700"
+              />
+              <span className="text-sm text-gray-700 dark:text-gray-300">
+                Make public (others can use this template)
+              </span>
+            </label>
+          </div>
+
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Only unchecked items will be included in the template.
+          </p>
+
+          {error && (
+            <div className="px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-red-700 dark:text-red-400 text-sm flex items-center gap-2">
+              <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              {error}
             </div>
-          </form>
-        )}
-      </div>
-    </div>
+          )}
+        </form>
+      )}
+    </Panel>
   );
 }
 

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,5 +1,6 @@
 /**
- * Settings modal/page component.
+ * Settings panel component.
+ * Uses Panel for slide-up drawer experience.
  */
 
 import { Link } from 'react-router-dom';
@@ -8,7 +9,7 @@ import { useNotifications } from '../hooks/useNotifications';
 import { useAuth } from '../hooks/useAuth';
 import { supportsHaptics } from '../lib/haptics';
 import { supportsPushNotifications } from '../lib/notifications';
-import { useFocusTrap } from '../hooks/useFocusTrap';
+import { Panel } from './ui/Panel';
 
 interface SettingsProps {
   onClose: () => void;
@@ -25,253 +26,252 @@ export function Settings({ onClose }: SettingsProps) {
     toggleNotifications,
     setReminderMinutes,
   } = useNotifications({ userDid: user?.did ?? null });
-  const dialogRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
 
   const handleToggle = (current: boolean, setter: (v: boolean) => void) => {
     haptic('light');
     setter(!current);
   };
 
-  return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="settings-title"
-        className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl max-w-md w-full overflow-hidden"
+  const header = (
+    <>
+      <h2 id="settings-title" className="text-xl font-bold text-gray-900 dark:text-gray-100">
+        ⚙️ Settings
+      </h2>
+      <button
+        onClick={onClose}
+        className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        aria-label="Close settings"
       >
-        {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
-          <h2 id="settings-title" className="text-xl font-bold text-gray-900 dark:text-gray-100">
-            ⚙️ Settings
-          </h2>
-          <button
-            onClick={onClose}
-            className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-            aria-label="Close settings"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </>
+  );
 
-        {/* Settings List */}
-        <div className="p-6 space-y-6">
-          {/* Appearance Section */}
+  const footer = (
+    <div className="p-4 bg-gray-50 dark:bg-gray-900/50">
+      <button
+        onClick={onClose}
+        className="w-full py-3 bg-amber-500 hover:bg-amber-600 text-white rounded-xl font-semibold transition-colors"
+      >
+        Done
+      </button>
+    </div>
+  );
+
+  return (
+    <Panel
+      isOpen={true}
+      onClose={onClose}
+      header={header}
+      footer={footer}
+      ariaLabelledBy="settings-title"
+    >
+      {/* Settings List */}
+      <div className="p-6 space-y-6">
+        {/* Appearance Section */}
+        <section>
+          <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4">
+            Appearance
+          </h3>
+          
+          {/* Dark Mode Toggle */}
+          <div className="flex items-center justify-between py-3">
+            <div className="flex items-center gap-3">
+              <span className="text-2xl">{darkMode ? '🌙' : '☀️'}</span>
+              <div>
+                <p className="font-medium text-gray-900 dark:text-gray-100">Dark Mode</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  {darkMode ? 'Currently in dark mode' : 'Currently in light mode'}
+                </p>
+              </div>
+            </div>
+            <button
+              onClick={() => handleToggle(darkMode, toggleDarkMode)}
+              className={`relative w-14 h-8 rounded-full transition-colors ${
+                darkMode ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'
+              }`}
+              role="switch"
+              aria-checked={darkMode}
+            >
+              <div
+                className={`absolute top-1 w-6 h-6 bg-white rounded-full shadow-md transition-transform ${
+                  darkMode ? 'translate-x-7' : 'translate-x-1'
+                }`}
+              />
+            </button>
+          </div>
+        </section>
+
+        {/* Accessibility Section */}
+        {supportsHaptics() && (
           <section>
             <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4">
-              Appearance
+              Accessibility
             </h3>
             
-            {/* Dark Mode Toggle */}
+            {/* Haptic Feedback Toggle */}
             <div className="flex items-center justify-between py-3">
               <div className="flex items-center gap-3">
-                <span className="text-2xl">{darkMode ? '🌙' : '☀️'}</span>
+                <span className="text-2xl">📳</span>
                 <div>
-                  <p className="font-medium text-gray-900 dark:text-gray-100">Dark Mode</p>
+                  <p className="font-medium text-gray-900 dark:text-gray-100">Haptic Feedback</p>
                   <p className="text-sm text-gray-500 dark:text-gray-400">
-                    {darkMode ? 'Currently in dark mode' : 'Currently in light mode'}
+                    Vibrate on interactions
                   </p>
                 </div>
               </div>
               <button
-                onClick={() => handleToggle(darkMode, toggleDarkMode)}
+                onClick={() => handleToggle(hapticsEnabled, setHapticsEnabled)}
                 className={`relative w-14 h-8 rounded-full transition-colors ${
-                  darkMode ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'
+                  hapticsEnabled ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'
                 }`}
                 role="switch"
-                aria-checked={darkMode}
+                aria-checked={hapticsEnabled}
               >
                 <div
                   className={`absolute top-1 w-6 h-6 bg-white rounded-full shadow-md transition-transform ${
-                    darkMode ? 'translate-x-7' : 'translate-x-1'
+                    hapticsEnabled ? 'translate-x-7' : 'translate-x-1'
                   }`}
                 />
               </button>
             </div>
           </section>
+        )}
 
-          {/* Accessibility Section */}
-          {supportsHaptics() && (
-            <section>
-              <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4">
-                Accessibility
-              </h3>
-              
-              {/* Haptic Feedback Toggle */}
-              <div className="flex items-center justify-between py-3">
-                <div className="flex items-center gap-3">
-                  <span className="text-2xl">📳</span>
-                  <div>
-                    <p className="font-medium text-gray-900 dark:text-gray-100">Haptic Feedback</p>
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      Vibrate on interactions
-                    </p>
-                  </div>
-                </div>
-                <button
-                  onClick={() => handleToggle(hapticsEnabled, setHapticsEnabled)}
-                  className={`relative w-14 h-8 rounded-full transition-colors ${
-                    hapticsEnabled ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'
-                  }`}
-                  role="switch"
-                  aria-checked={hapticsEnabled}
-                >
-                  <div
-                    className={`absolute top-1 w-6 h-6 bg-white rounded-full shadow-md transition-transform ${
-                      hapticsEnabled ? 'translate-x-7' : 'translate-x-1'
-                    }`}
-                  />
-                </button>
-              </div>
-            </section>
-          )}
-
-          {/* Notifications Section */}
-          {supportsPushNotifications() && (
-            <section>
-              <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4">
-                Notifications
-              </h3>
-              
-              {/* Push Notifications Toggle */}
-              <div className="flex items-center justify-between py-3">
-                <div className="flex items-center gap-3">
-                  <span className="text-2xl">🔔</span>
-                  <div>
-                    <p className="font-medium text-gray-900 dark:text-gray-100">Push Notifications</p>
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      {notificationPermission === 'denied' 
-                        ? 'Blocked in browser settings'
-                        : notificationsEnabled 
-                          ? 'Get notified when items are due' 
-                          : 'Enable notifications for due dates'}
-                    </p>
-                  </div>
-                </div>
-                <button
-                  onClick={async () => {
-                    haptic('light');
-                    await toggleNotifications();
-                  }}
-                  disabled={notificationsLoading || notificationPermission === 'denied'}
-                  className={`relative w-14 h-8 rounded-full transition-colors ${
-                    notificationsEnabled ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'
-                  } ${notificationsLoading || notificationPermission === 'denied' ? 'opacity-50 cursor-not-allowed' : ''}`}
-                  role="switch"
-                  aria-checked={notificationsEnabled}
-                >
-                  <div
-                    className={`absolute top-1 w-6 h-6 bg-white rounded-full shadow-md transition-transform ${
-                      notificationsEnabled ? 'translate-x-7' : 'translate-x-1'
-                    }`}
-                  />
-                </button>
-              </div>
-
-              {/* Reminder Time */}
-              {notificationsEnabled && (
-                <div className="py-3">
-                  <div className="flex items-center gap-3 mb-3">
-                    <span className="text-2xl">⏰</span>
-                    <div>
-                      <p className="font-medium text-gray-900 dark:text-gray-100">Reminder Time</p>
-                      <p className="text-sm text-gray-500 dark:text-gray-400">
-                        How early to remind you before due date
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex gap-2 ml-11">
-                    {[
-                      { value: 15, label: '15m' },
-                      { value: 30, label: '30m' },
-                      { value: 60, label: '1h' },
-                      { value: 120, label: '2h' },
-                      { value: 1440, label: '1d' },
-                    ].map(({ value, label }) => (
-                      <button
-                        key={value}
-                        onClick={() => {
-                          haptic('light');
-                          setReminderMinutes(value);
-                        }}
-                        className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
-                          reminderMinutes === value
-                            ? 'bg-amber-500 text-white'
-                            : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-                        }`}
-                      >
-                        {label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </section>
-          )}
-
-          {/* Account Section */}
+        {/* Notifications Section */}
+        {supportsPushNotifications() && (
           <section>
             <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4">
-              Account
+              Notifications
             </h3>
             
-            <Link
-              to="/profile"
-              onClick={() => {
-                haptic('light');
-                onClose();
-              }}
-              className="flex items-center justify-between py-3 px-4 bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-xl transition-colors"
-            >
+            {/* Push Notifications Toggle */}
+            <div className="flex items-center justify-between py-3">
               <div className="flex items-center gap-3">
-                <span className="text-2xl">👤</span>
+                <span className="text-2xl">🔔</span>
                 <div>
-                  <p className="font-medium text-gray-900 dark:text-gray-100">Your Profile</p>
+                  <p className="font-medium text-gray-900 dark:text-gray-100">Push Notifications</p>
                   <p className="text-sm text-gray-500 dark:text-gray-400">
-                    View stats and account details
+                    {notificationPermission === 'denied' 
+                      ? 'Blocked in browser settings'
+                      : notificationsEnabled 
+                        ? 'Get notified when items are due' 
+                        : 'Enable notifications for due dates'}
                   </p>
                 </div>
               </div>
-              <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </Link>
-          </section>
+              <button
+                onClick={async () => {
+                  haptic('light');
+                  await toggleNotifications();
+                }}
+                disabled={notificationsLoading || notificationPermission === 'denied'}
+                className={`relative w-14 h-8 rounded-full transition-colors ${
+                  notificationsEnabled ? 'bg-amber-500' : 'bg-gray-300 dark:bg-gray-600'
+                } ${notificationsLoading || notificationPermission === 'denied' ? 'opacity-50 cursor-not-allowed' : ''}`}
+                role="switch"
+                aria-checked={notificationsEnabled}
+              >
+                <div
+                  className={`absolute top-1 w-6 h-6 bg-white rounded-full shadow-md transition-transform ${
+                    notificationsEnabled ? 'translate-x-7' : 'translate-x-1'
+                  }`}
+                />
+              </button>
+            </div>
 
-          {/* About Section */}
-          <section>
-            <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4">
-              About
-            </h3>
-            
-            <div className="bg-gradient-to-r from-amber-50 to-orange-50 dark:from-gray-700 dark:to-gray-700 rounded-xl p-4">
-              <div className="flex items-center gap-3 mb-3">
-                <span className="text-3xl">💩</span>
-                <div>
-                  <p className="font-bold text-gray-900 dark:text-gray-100">Poo App</p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">Version 1.0.0</p>
+            {/* Reminder Time */}
+            {notificationsEnabled && (
+              <div className="py-3">
+                <div className="flex items-center gap-3 mb-3">
+                  <span className="text-2xl">⏰</span>
+                  <div>
+                    <p className="font-medium text-gray-900 dark:text-gray-100">Reminder Time</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      How early to remind you before due date
+                    </p>
+                  </div>
+                </div>
+                <div className="flex gap-2 ml-11">
+                  {[
+                    { value: 15, label: '15m' },
+                    { value: 30, label: '30m' },
+                    { value: 60, label: '1h' },
+                    { value: 120, label: '2h' },
+                    { value: 1440, label: '1d' },
+                  ].map(({ value, label }) => (
+                    <button
+                      key={value}
+                      onClick={() => {
+                        haptic('light');
+                        setReminderMinutes(value);
+                      }}
+                      className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
+                        reminderMinutes === value
+                          ? 'bg-amber-500 text-white'
+                          : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  ))}
                 </div>
               </div>
-              <p className="text-sm text-gray-600 dark:text-gray-300">
-                Organize your life while you poop. Powered by Originals Protocol.
-              </p>
-            </div>
+            )}
           </section>
-        </div>
+        )}
 
-        {/* Footer */}
-        <div className="p-6 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50">
-          <button
-            onClick={onClose}
-            className="w-full py-3 bg-amber-500 hover:bg-amber-600 text-white rounded-xl font-semibold transition-colors"
+        {/* Account Section */}
+        <section>
+          <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4">
+            Account
+          </h3>
+          
+          <Link
+            to="/profile"
+            onClick={() => {
+              haptic('light');
+              onClose();
+            }}
+            className="flex items-center justify-between py-3 px-4 bg-gray-50 dark:bg-gray-700 hover:bg-gray-100 dark:hover:bg-gray-600 rounded-xl transition-colors"
           >
-            Done
-          </button>
-        </div>
+            <div className="flex items-center gap-3">
+              <span className="text-2xl">👤</span>
+              <div>
+                <p className="font-medium text-gray-900 dark:text-gray-100">Your Profile</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  View stats and account details
+                </p>
+              </div>
+            </div>
+            <svg className="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </Link>
+        </section>
+
+        {/* About Section */}
+        <section>
+          <h3 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4">
+            About
+          </h3>
+          
+          <div className="bg-gradient-to-r from-amber-50 to-orange-50 dark:from-gray-700 dark:to-gray-700 rounded-xl p-4">
+            <div className="flex items-center gap-3 mb-3">
+              <span className="text-3xl">💩</span>
+              <div>
+                <p className="font-bold text-gray-900 dark:text-gray-100">Poo App</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">Version 1.0.0</p>
+              </div>
+            </div>
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              Organize your life while you poop. Powered by Originals Protocol.
+            </p>
+          </div>
+        </section>
       </div>
-    </div>
+    </Panel>
   );
 }

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -1,5 +1,6 @@
 /**
- * Modal for sharing a list via invite link.
+ * Panel for sharing a list via invite link.
+ * Uses Panel component for slide-up drawer experience.
  * Updated for Phase 3: supports role-based invites.
  */
 
@@ -8,7 +9,8 @@ import { useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import type { Doc } from "../../convex/_generated/dataModel";
 import { getRoleDescription } from "../lib/permissions";
-import { useFocusTrap } from "../hooks/useFocusTrap";
+import { useSettings } from "../hooks/useSettings";
+import { Panel } from "./ui/Panel";
 
 interface ShareModalProps {
   list: Doc<"lists">;
@@ -19,7 +21,7 @@ type InviteRole = "editor" | "viewer";
 
 export function ShareModal({ list, onClose }: ShareModalProps) {
   const createInvite = useMutation(api.invites.createInvite);
-  const dialogRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
+  const { haptic } = useSettings();
 
   const [selectedRole, setSelectedRole] = useState<InviteRole>("editor");
   const [inviteLink, setInviteLink] = useState<string | null>(null);
@@ -58,6 +60,7 @@ export function ShareModal({ list, onClose }: ShareModalProps) {
   }, []);
 
   const handleRoleChange = (role: InviteRole) => {
+    haptic('light');
     setSelectedRole(role);
     // Generate new invite with selected role
     generateInvite(role);
@@ -68,113 +71,148 @@ export function ShareModal({ list, onClose }: ShareModalProps) {
 
     try {
       await navigator.clipboard.writeText(inviteLink);
+      haptic('success');
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), 2000);
     } catch (err) {
       console.error("Failed to copy:", err);
+      haptic('error');
     }
   };
 
-  return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="share-dialog-title"
-        aria-describedby="share-dialog-description"
-        className="bg-white rounded-lg shadow-xl max-w-md w-full p-6"
-      >
-        <h2 id="share-dialog-title" className="text-xl font-bold text-gray-900 mb-2">
-          Share "{list.name}"
+  const header = (
+    <>
+      <div>
+        <h2 id="share-dialog-title" className="text-lg font-bold text-gray-900 dark:text-gray-100">
+          🔗 Share List
         </h2>
-        <p id="share-dialog-description" className="text-gray-600 mb-4">
-          Send this link to invite someone to the list.
+        <p className="text-sm text-gray-500 dark:text-gray-400 truncate max-w-[200px]">
+          {list.name}
+        </p>
+      </div>
+      <button
+        onClick={onClose}
+        className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        aria-label="Close"
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </>
+  );
+
+  const footer = (
+    <div className="px-5 py-4">
+      <button
+        onClick={onClose}
+        className="w-full px-4 py-3 bg-amber-500 hover:bg-amber-600 text-white rounded-xl font-semibold transition-colors"
+      >
+        Done
+      </button>
+    </div>
+  );
+
+  return (
+    <Panel
+      isOpen={true}
+      onClose={onClose}
+      header={header}
+      footer={footer}
+      ariaLabelledBy="share-dialog-title"
+    >
+      {/* Content */}
+      <div className="p-5 space-y-5">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          Send this link to invite someone to collaborate on your list.
         </p>
 
         {/* Role selector */}
-        <div className="mb-4">
-          <label className="block text-sm font-medium text-gray-700 mb-2">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
             Invite as
           </label>
           <div className="flex gap-2">
             <button
               onClick={() => handleRoleChange("editor")}
               disabled={isCreating}
-              className={`flex-1 px-4 py-2 rounded-md border text-sm font-medium transition-colors ${
+              className={`flex-1 px-4 py-3 rounded-xl border-2 text-sm font-medium transition-all ${
                 selectedRole === "editor"
-                  ? "bg-blue-50 border-blue-600 text-blue-700"
-                  : "bg-white border-gray-300 text-gray-700 hover:bg-gray-50"
+                  ? "bg-amber-50 dark:bg-amber-900/20 border-amber-500 text-amber-700 dark:text-amber-400"
+                  : "bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600"
               } ${isCreating ? "opacity-50 cursor-not-allowed" : ""}`}
             >
+              <span className="text-lg block mb-1">✏️</span>
               Editor
             </button>
             <button
               onClick={() => handleRoleChange("viewer")}
               disabled={isCreating}
-              className={`flex-1 px-4 py-2 rounded-md border text-sm font-medium transition-colors ${
+              className={`flex-1 px-4 py-3 rounded-xl border-2 text-sm font-medium transition-all ${
                 selectedRole === "viewer"
-                  ? "bg-blue-50 border-blue-600 text-blue-700"
-                  : "bg-white border-gray-300 text-gray-700 hover:bg-gray-50"
+                  ? "bg-amber-50 dark:bg-amber-900/20 border-amber-500 text-amber-700 dark:text-amber-400"
+                  : "bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600"
               } ${isCreating ? "opacity-50 cursor-not-allowed" : ""}`}
             >
+              <span className="text-lg block mb-1">👁️</span>
               Viewer
             </button>
           </div>
-          <p className="mt-1 text-xs text-gray-500">
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
             {getRoleDescription(selectedRole)}
           </p>
         </div>
 
         {isCreating && (
-          <div className="mb-4 p-3 bg-gray-100 rounded-md text-center text-gray-500">
-            Creating invite link...
+          <div className="p-4 bg-gray-50 dark:bg-gray-900 rounded-xl text-center">
+            <div className="flex items-center justify-center gap-2 text-gray-500 dark:text-gray-400">
+              <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+              </svg>
+              Creating invite link...
+            </div>
           </div>
         )}
 
         {error && (
-          <div className="mb-4 p-3 bg-red-50 rounded-md text-red-600 text-sm">
+          <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-red-700 dark:text-red-400 text-sm flex items-center gap-2">
+            <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
             {error}
           </div>
         )}
 
         {inviteLink && !isCreating && (
-          <>
-            <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Invite link
-              </label>
-              <div className="flex gap-2">
-                <input
-                  type="text"
-                  value={inviteLink}
-                  readOnly
-                  className="flex-1 px-3 py-2 text-gray-900 border border-gray-300 rounded-md bg-gray-50 text-sm"
-                />
-                <button
-                  onClick={handleCopy}
-                  className="px-4 py-2 bg-blue-600 text-white rounded-md font-medium hover:bg-blue-700"
-                >
-                  {isCopied ? "Copied!" : "Copy"}
-                </button>
-              </div>
+          <div className="space-y-3">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Invite link
+            </label>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                value={inviteLink}
+                readOnly
+                className="flex-1 px-4 py-3 text-gray-900 dark:text-gray-100 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl text-sm"
+              />
+              <button
+                onClick={handleCopy}
+                className={`px-4 py-3 rounded-xl font-medium transition-all ${
+                  isCopied
+                    ? "bg-green-500 text-white"
+                    : "bg-amber-500 hover:bg-amber-600 text-white"
+                }`}
+              >
+                {isCopied ? "✓" : "Copy"}
+              </button>
             </div>
-
-            <p className="text-xs text-gray-500 mb-4">
+            <p className="text-xs text-gray-500 dark:text-gray-400">
               This link expires in 24 hours and can only be used once.
             </p>
-          </>
+          </div>
         )}
-
-        <div className="flex justify-end">
-          <button
-            onClick={onClose}
-            className="px-4 py-2 text-gray-700 bg-gray-100 rounded-md font-medium hover:bg-gray-200"
-          >
-            Done
-          </button>
-        </div>
       </div>
-    </div>
+    </Panel>
   );
 }

--- a/src/components/TemplatePickerModal.tsx
+++ b/src/components/TemplatePickerModal.tsx
@@ -1,6 +1,7 @@
 /**
- * Modal for selecting a template when creating a new list.
+ * Panel for selecting a template when creating a new list.
  * Shows built-in templates and user's saved templates.
+ * Uses Panel component for slide-up drawer experience.
  */
 
 import { useState } from "react";
@@ -9,10 +10,10 @@ import { useNavigate } from "react-router-dom";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
 import { useCurrentUser } from "../hooks/useCurrentUser";
-import { useFocusTrap } from "../hooks/useFocusTrap";
 import { useSettings } from "../hooks/useSettings";
 import { createListAsset } from "../lib/originals";
 import { BUILTIN_TEMPLATES, type BuiltinTemplate } from "../lib/builtinTemplates";
+import { Panel } from "./ui/Panel";
 
 interface TemplatePickerModalProps {
   onClose: () => void;
@@ -23,7 +24,6 @@ export function TemplatePickerModal({ onClose, onCreateBlank }: TemplatePickerMo
   const { did } = useCurrentUser();
   const navigate = useNavigate();
   const { haptic } = useSettings();
-  const dialogRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
 
   const [selectedTemplate, setSelectedTemplate] = useState<BuiltinTemplate | null>(null);
   const [customName, setCustomName] = useState("");
@@ -112,212 +112,226 @@ export function TemplatePickerModal({ onClose, onCreateBlank }: TemplatePickerMo
     }
   };
 
-  return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="template-picker-title"
-        className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-lg w-full max-h-[85vh] overflow-hidden animate-slide-up flex flex-col"
-      >
-        {/* Header */}
-        <div className="px-6 pt-6 pb-4 border-b border-gray-200 dark:border-gray-700">
-          <div className="flex items-center gap-3 mb-2">
-            <span className="text-3xl">📁</span>
-            <h2 id="template-picker-title" className="text-xl font-bold text-gray-900 dark:text-gray-100">
-              {selectedTemplate ? "Customize Template" : "Choose a Template"}
-            </h2>
-          </div>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
+  const header = (
+    <>
+      <div className="flex items-center gap-3">
+        <span className="text-2xl">📁</span>
+        <div>
+          <h2 id="template-picker-title" className="text-lg font-bold text-gray-900 dark:text-gray-100">
+            {selectedTemplate ? "Customize Template" : "Choose a Template"}
+          </h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
             {selectedTemplate 
               ? "Customize the name or create with defaults"
-              : "Start with a template or create a blank list"
+              : "Start with a template or blank list"
             }
           </p>
         </div>
+      </div>
+      <button
+        onClick={() => {
+          haptic('light');
+          onClose();
+        }}
+        className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        aria-label="Close"
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </>
+  );
 
-        {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6">
-          {selectedTemplate ? (
-            /* Template customization view */
-            <div className="space-y-4">
-              <button
-                onClick={() => {
-                  haptic('light');
-                  setSelectedTemplate(null);
-                }}
-                className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-                </svg>
-                Back to templates
-              </button>
-
-              <div className="bg-amber-50 dark:bg-amber-900/20 rounded-xl p-4 flex items-start gap-3">
-                <span className="text-2xl">{selectedTemplate.emoji}</span>
-                <div>
-                  <p className="font-medium text-gray-900 dark:text-gray-100">{selectedTemplate.name}</p>
-                  <p className="text-sm text-gray-600 dark:text-gray-400">{selectedTemplate.items.length} items</p>
-                </div>
-              </div>
-
-              <div>
-                <label htmlFor="listName" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                  List name
-                </label>
-                <input
-                  id="listName"
-                  type="text"
-                  value={customName}
-                  onChange={(e) => setCustomName(e.target.value)}
-                  placeholder={selectedTemplate.name}
-                  className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:border-amber-500 dark:focus:border-amber-500 focus:ring-4 focus:ring-amber-500/10 transition-all disabled:opacity-50"
-                  disabled={isCreating}
-                />
-              </div>
-
-              <div>
-                <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                  Items included:
-                </p>
-                <ul className="bg-gray-50 dark:bg-gray-900 rounded-xl p-3 max-h-40 overflow-y-auto space-y-1">
-                  {selectedTemplate.items.map((item, idx) => (
-                    <li key={idx} className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
-                      <span className="w-4 h-4 rounded border border-gray-300 dark:border-gray-600" />
-                      <span>{item.name}</span>
-                      {item.priority && (
-                        <span className={`text-xs px-1.5 py-0.5 rounded ${
-                          item.priority === 'high' ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' :
-                          item.priority === 'medium' ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400' :
-                          'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-                        }`}>
-                          {item.priority}
-                        </span>
-                      )}
-                    </li>
-                  ))}
-                </ul>
-              </div>
-
-              {error && (
-                <div className="px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-red-700 dark:text-red-400 text-sm flex items-center gap-2">
-                  <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                  {error}
-                </div>
-              )}
-            </div>
+  const footer = (
+    <div className="px-5 py-4 flex gap-3">
+      <button
+        type="button"
+        onClick={() => {
+          haptic('light');
+          onClose();
+        }}
+        disabled={isCreating}
+        className="flex-1 px-4 py-3 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-xl font-medium hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors"
+      >
+        Cancel
+      </button>
+      {selectedTemplate && (
+        <button
+          type="button"
+          onClick={handleCreateFromBuiltin}
+          disabled={isCreating}
+          className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
+        >
+          {isCreating ? (
+            <span className="flex items-center justify-center gap-2">
+              <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+              </svg>
+              Creating...
+            </span>
           ) : (
-            /* Template selection view */
-            <div className="space-y-6">
-              {/* Blank list option */}
-              <button
-                onClick={() => {
-                  haptic('light');
-                  onCreateBlank();
-                }}
-                className="w-full flex items-center gap-4 p-4 bg-gradient-to-r from-amber-50 to-orange-50 dark:from-amber-900/20 dark:to-orange-900/20 border-2 border-dashed border-amber-300 dark:border-amber-700 rounded-xl hover:border-amber-400 dark:hover:border-amber-600 transition-colors text-left"
-              >
-                <span className="text-2xl">✨</span>
-                <div>
-                  <p className="font-medium text-gray-900 dark:text-gray-100">Blank List</p>
-                  <p className="text-sm text-gray-500 dark:text-gray-400">Start from scratch</p>
-                </div>
-              </button>
+            "Create List"
+          )}
+        </button>
+      )}
+    </div>
+  );
 
-              {/* Built-in templates */}
+  return (
+    <Panel
+      isOpen={true}
+      onClose={onClose}
+      header={header}
+      footer={footer}
+      ariaLabelledBy="template-picker-title"
+    >
+      {/* Content */}
+      <div className="p-5">
+        {selectedTemplate ? (
+          /* Template customization view */
+          <div className="space-y-4">
+            <button
+              onClick={() => {
+                haptic('light');
+                setSelectedTemplate(null);
+              }}
+              className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              </svg>
+              Back to templates
+            </button>
+
+            <div className="bg-amber-50 dark:bg-amber-900/20 rounded-xl p-4 flex items-start gap-3">
+              <span className="text-2xl">{selectedTemplate.emoji}</span>
+              <div>
+                <p className="font-medium text-gray-900 dark:text-gray-100">{selectedTemplate.name}</p>
+                <p className="text-sm text-gray-600 dark:text-gray-400">{selectedTemplate.items.length} items</p>
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="listName" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                List name
+              </label>
+              <input
+                id="listName"
+                type="text"
+                value={customName}
+                onChange={(e) => setCustomName(e.target.value)}
+                placeholder={selectedTemplate.name}
+                className="w-full px-4 py-3 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 border-2 border-gray-200 dark:border-gray-700 rounded-xl focus:outline-none focus:border-amber-500 dark:focus:border-amber-500 focus:ring-4 focus:ring-amber-500/10 transition-all disabled:opacity-50"
+                disabled={isCreating}
+              />
+            </div>
+
+            <div>
+              <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Items included:
+              </p>
+              <ul className="bg-gray-50 dark:bg-gray-900 rounded-xl p-3 max-h-40 overflow-y-auto space-y-1">
+                {selectedTemplate.items.map((item, idx) => (
+                  <li key={idx} className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+                    <span className="w-4 h-4 rounded border border-gray-300 dark:border-gray-600" />
+                    <span>{item.name}</span>
+                    {item.priority && (
+                      <span className={`text-xs px-1.5 py-0.5 rounded ${
+                        item.priority === 'high' ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400' :
+                        item.priority === 'medium' ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400' :
+                        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+                      }`}>
+                        {item.priority}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {error && (
+              <div className="px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-red-700 dark:text-red-400 text-sm flex items-center gap-2">
+                <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                {error}
+              </div>
+            )}
+          </div>
+        ) : (
+          /* Template selection view */
+          <div className="space-y-6">
+            {/* Blank list option */}
+            <button
+              onClick={() => {
+                haptic('light');
+                onCreateBlank();
+              }}
+              className="w-full flex items-center gap-4 p-4 bg-gradient-to-r from-amber-50 to-orange-50 dark:from-amber-900/20 dark:to-orange-900/20 border-2 border-dashed border-amber-300 dark:border-amber-700 rounded-xl hover:border-amber-400 dark:hover:border-amber-600 transition-colors text-left"
+            >
+              <span className="text-2xl">✨</span>
+              <div>
+                <p className="font-medium text-gray-900 dark:text-gray-100">Blank List</p>
+                <p className="text-sm text-gray-500 dark:text-gray-400">Start from scratch</p>
+              </div>
+            </button>
+
+            {/* Built-in templates */}
+            <div>
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
+                Quick Start Templates
+              </h3>
+              <div className="grid gap-3">
+                {BUILTIN_TEMPLATES.map((template) => (
+                  <button
+                    key={template.id}
+                    onClick={() => handleSelectBuiltin(template)}
+                    className="w-full flex items-center gap-4 p-4 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-xl hover:border-amber-400 dark:hover:border-amber-500 hover:shadow-md transition-all text-left"
+                  >
+                    <span className="text-2xl">{template.emoji}</span>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium text-gray-900 dark:text-gray-100">{template.name}</p>
+                      <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{template.description}</p>
+                    </div>
+                    <span className="text-xs text-gray-400 dark:text-gray-500">{template.items.length} items</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* User's saved templates */}
+            {userTemplates && userTemplates.length > 0 && (
               <div>
                 <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
-                  Quick Start Templates
+                  My Templates
                 </h3>
                 <div className="grid gap-3">
-                  {BUILTIN_TEMPLATES.map((template) => (
+                  {userTemplates.map((template) => (
                     <button
-                      key={template.id}
-                      onClick={() => handleSelectBuiltin(template)}
-                      className="w-full flex items-center gap-4 p-4 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-xl hover:border-amber-400 dark:hover:border-amber-500 hover:shadow-md transition-all text-left"
+                      key={template._id}
+                      onClick={() => handleCreateFromSaved(template._id, template.name)}
+                      disabled={isCreating}
+                      className="w-full flex items-center gap-4 p-4 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-xl hover:border-amber-400 dark:hover:border-amber-500 hover:shadow-md transition-all text-left disabled:opacity-50"
                     >
-                      <span className="text-2xl">{template.emoji}</span>
+                      <span className="text-2xl">📄</span>
                       <div className="flex-1 min-w-0">
                         <p className="font-medium text-gray-900 dark:text-gray-100">{template.name}</p>
-                        <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{template.description}</p>
+                        {template.description && (
+                          <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{template.description}</p>
+                        )}
                       </div>
                       <span className="text-xs text-gray-400 dark:text-gray-500">{template.items.length} items</span>
                     </button>
                   ))}
                 </div>
               </div>
-
-              {/* User's saved templates */}
-              {userTemplates && userTemplates.length > 0 && (
-                <div>
-                  <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">
-                    My Templates
-                  </h3>
-                  <div className="grid gap-3">
-                    {userTemplates.map((template) => (
-                      <button
-                        key={template._id}
-                        onClick={() => handleCreateFromSaved(template._id, template.name)}
-                        disabled={isCreating}
-                        className="w-full flex items-center gap-4 p-4 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-xl hover:border-amber-400 dark:hover:border-amber-500 hover:shadow-md transition-all text-left disabled:opacity-50"
-                      >
-                        <span className="text-2xl">📄</span>
-                        <div className="flex-1 min-w-0">
-                          <p className="font-medium text-gray-900 dark:text-gray-100">{template.name}</p>
-                          {template.description && (
-                            <p className="text-sm text-gray-500 dark:text-gray-400 truncate">{template.description}</p>
-                          )}
-                        </div>
-                        <span className="text-xs text-gray-400 dark:text-gray-500">{template.items.length} items</span>
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-
-        {/* Footer */}
-        <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex gap-3">
-          <button
-            type="button"
-            onClick={() => {
-              haptic('light');
-              onClose();
-            }}
-            disabled={isCreating}
-            className="flex-1 px-4 py-3 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-xl font-medium hover:bg-gray-200 dark:hover:bg-gray-600 disabled:opacity-50 transition-colors"
-          >
-            Cancel
-          </button>
-          {selectedTemplate && (
-            <button
-              type="button"
-              onClick={handleCreateFromBuiltin}
-              disabled={isCreating}
-              className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
-            >
-              {isCreating ? (
-                <span className="flex items-center justify-center gap-2">
-                  <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
-                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                  </svg>
-                  Creating...
-                </span>
-              ) : (
-                "Create List"
-              )}
-            </button>
-          )}
-        </div>
+            )}
+          </div>
+        )}
       </div>
-    </div>
+    </Panel>
   );
 }
 

--- a/src/components/publish/PublishModal.tsx
+++ b/src/components/publish/PublishModal.tsx
@@ -1,5 +1,6 @@
 /**
- * Modal for publishing a list to did:webvh.
+ * Panel for publishing a list to did:webvh.
+ * Uses Panel component for slide-up drawer experience.
  *
  * Phase 4: Allows list owners to publish their lists publicly.
  * Published lists are verifiable and can be viewed by anyone.
@@ -10,8 +11,9 @@ import { useAction, useMutation, useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import type { Doc } from "../../../convex/_generated/dataModel";
 import { useCurrentUser } from "../../hooks/useCurrentUser";
-import { useFocusTrap } from "../../hooks/useFocusTrap";
+import { useSettings } from "../../hooks/useSettings";
 import { getPublicListUrl } from "../../lib/publication";
+import { Panel } from "../ui/Panel";
 
 interface PublishModalProps {
   list: Doc<"lists">;
@@ -22,13 +24,13 @@ const PUBLICATION_DOMAIN = "lisa.aviary.tech";
 
 export function PublishModal({ list, onClose }: PublishModalProps) {
   const { did, subOrgId } = useCurrentUser();
+  const { haptic } = useSettings();
   const createListDID = useAction(api.didCreation.createListDID);
   const publishListMutation = useMutation(api.publication.publishList);
   const unpublishListMutation = useMutation(api.publication.unpublishList);
   const publicationStatus = useQuery(api.publication.getPublicationStatus, {
     listId: list._id,
   });
-  const dialogRef = useFocusTrap<HTMLDivElement>({ onEscape: onClose });
 
   const [isPublishing, setIsPublishing] = useState(false);
   const [isUnpublishing, setIsUnpublishing] = useState(false);
@@ -48,6 +50,7 @@ export function PublishModal({ list, onClose }: PublishModalProps) {
 
     setIsPublishing(true);
     setError(null);
+    haptic('medium');
 
     try {
       // Create the slug from list ID (alphanumeric only)
@@ -68,11 +71,14 @@ export function PublishModal({ list, onClose }: PublishModalProps) {
         didLog: JSON.stringify(result.didLog),
         publisherDid: did,
       });
+      
+      haptic('success');
     } catch (err) {
       console.error("[PublishModal] Failed to publish:", err);
       setError(
         err instanceof Error ? err.message : "Failed to publish list"
       );
+      haptic('error');
     } finally {
       setIsPublishing(false);
     }
@@ -86,17 +92,20 @@ export function PublishModal({ list, onClose }: PublishModalProps) {
 
     setIsUnpublishing(true);
     setError(null);
+    haptic('medium');
 
     try {
       await unpublishListMutation({
         listId: list._id,
         userDid: did,
       });
+      haptic('success');
     } catch (err) {
       console.error("[PublishModal] Failed to unpublish:", err);
       setError(
         err instanceof Error ? err.message : "Failed to unpublish list"
       );
+      haptic('error');
     } finally {
       setIsUnpublishing(false);
     }
@@ -107,47 +116,121 @@ export function PublishModal({ list, onClose }: PublishModalProps) {
 
     try {
       await navigator.clipboard.writeText(publicUrl);
+      haptic('success');
       setIsCopied(true);
       setTimeout(() => setIsCopied(false), 2000);
     } catch (err) {
       console.error("Failed to copy:", err);
+      haptic('error');
     }
   };
+
+  const header = (
+    <>
+      <div className="flex items-center gap-3">
+        <span className="text-2xl">{isPublished ? "🌐" : "📤"}</span>
+        <div>
+          <h2 id="publish-dialog-title" className="text-lg font-bold text-gray-900 dark:text-gray-100">
+            {isPublished ? "Published List" : "Publish List"}
+          </h2>
+          <p className="text-xs text-gray-500 dark:text-gray-400 truncate max-w-[200px]">
+            {list.name}
+          </p>
+        </div>
+      </div>
+      <button
+        onClick={onClose}
+        className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+        aria-label="Close"
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+    </>
+  );
+
+  const footer = isPublished ? (
+    <div className="px-5 py-4 flex gap-3">
+      <button
+        onClick={handleUnpublish}
+        disabled={isUnpublishing}
+        className="flex-1 px-4 py-3 text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 rounded-xl font-medium hover:bg-red-100 dark:hover:bg-red-900/30 disabled:opacity-50 transition-colors"
+      >
+        {isUnpublishing ? "Unpublishing..." : "Unpublish"}
+      </button>
+      <button
+        onClick={onClose}
+        className="flex-1 px-4 py-3 bg-amber-500 hover:bg-amber-600 text-white rounded-xl font-semibold transition-colors"
+      >
+        Done
+      </button>
+    </div>
+  ) : (
+    <div className="px-5 py-4 flex gap-3">
+      <button
+        onClick={() => {
+          haptic('light');
+          onClose();
+        }}
+        className="flex-1 px-4 py-3 text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-xl font-medium hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors"
+      >
+        Cancel
+      </button>
+      <button
+        onClick={handlePublish}
+        disabled={isPublishing}
+        className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 transition-all"
+      >
+        {isPublishing ? (
+          <span className="flex items-center justify-center gap-2">
+            <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+            </svg>
+            Publishing...
+          </span>
+        ) : (
+          "Publish List"
+        )}
+      </button>
+    </div>
+  );
 
   // Loading state while fetching publication status
   if (publicationStatus === undefined) {
     return (
-      <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-        <div
-          ref={dialogRef}
-          role="dialog"
-          aria-modal="true"
-          aria-label="Loading publication status"
-          className="bg-white rounded-lg shadow-xl max-w-md w-full p-6"
-        >
-          <div className="text-center text-gray-500">Loading...</div>
+      <Panel
+        isOpen={true}
+        onClose={onClose}
+        title="Loading..."
+        ariaLabelledBy="publish-dialog-title"
+      >
+        <div className="p-5">
+          <div className="flex items-center justify-center py-8">
+            <svg className="w-8 h-8 animate-spin text-amber-500" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+            </svg>
+          </div>
         </div>
-      </div>
+      </Panel>
     );
   }
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="publish-dialog-title"
-        className="bg-white rounded-lg shadow-xl max-w-md w-full p-6"
-      >
-        <h2 id="publish-dialog-title" className="text-xl font-bold text-gray-900 mb-2">
-          {isPublished ? "Published List" : "Publish List"}
-        </h2>
-
+    <Panel
+      isOpen={true}
+      onClose={onClose}
+      header={header}
+      footer={footer}
+      ariaLabelledBy="publish-dialog-title"
+    >
+      <div className="p-5 space-y-4">
         {isPublished ? (
           <>
-            <div className="mb-4 p-3 bg-green-50 rounded-md">
-              <div className="flex items-center gap-2 text-green-800">
+            <div className="p-4 bg-green-50 dark:bg-green-900/20 rounded-xl">
+              <div className="flex items-center gap-2 text-green-800 dark:text-green-400">
                 <svg
                   className="w-5 h-5"
                   fill="none"
@@ -163,13 +246,13 @@ export function PublishModal({ list, onClose }: PublishModalProps) {
                 </svg>
                 <span className="font-medium">This list is published</span>
               </div>
-              <p className="mt-1 text-sm text-green-700">
+              <p className="mt-1 text-sm text-green-700 dark:text-green-500">
                 Anyone with the link can view this list.
               </p>
             </div>
 
-            <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
                 Public URL
               </label>
               <div className="flex gap-2">
@@ -177,59 +260,39 @@ export function PublishModal({ list, onClose }: PublishModalProps) {
                   type="text"
                   value={publicUrl ?? ""}
                   readOnly
-                  className="flex-1 px-3 py-2 text-gray-900 border border-gray-300 rounded-md bg-gray-50 text-sm"
+                  className="flex-1 px-4 py-3 text-gray-900 dark:text-gray-100 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl text-sm"
                 />
                 <button
                   onClick={handleCopy}
-                  className="px-4 py-2 bg-blue-600 text-white rounded-md font-medium hover:bg-blue-700"
+                  className={`px-4 py-3 rounded-xl font-medium transition-all ${
+                    isCopied
+                      ? "bg-green-500 text-white"
+                      : "bg-amber-500 hover:bg-amber-600 text-white"
+                  }`}
                 >
-                  {isCopied ? "Copied!" : "Copy"}
+                  {isCopied ? "✓" : "Copy"}
                 </button>
               </div>
             </div>
 
-            <div className="mb-4 p-3 bg-gray-50 rounded-md">
-              <p className="text-sm text-gray-600">
+            <div className="p-4 bg-gray-50 dark:bg-gray-900 rounded-xl">
+              <p className="text-sm text-gray-600 dark:text-gray-400">
                 <span className="font-medium">DID:</span>{" "}
                 <span className="font-mono text-xs break-all">
                   {publicationStatus.webvhDid}
                 </span>
               </p>
             </div>
-
-            {error && (
-              <div className="mb-4 p-3 bg-red-50 rounded-md text-red-600 text-sm">
-                {error}
-              </div>
-            )}
-
-            <div className="flex justify-between">
-              <button
-                onClick={handleUnpublish}
-                disabled={isUnpublishing}
-                className={`px-4 py-2 text-red-600 bg-red-50 rounded-md font-medium hover:bg-red-100 ${
-                  isUnpublishing ? "opacity-50 cursor-not-allowed" : ""
-                }`}
-              >
-                {isUnpublishing ? "Unpublishing..." : "Unpublish"}
-              </button>
-              <button
-                onClick={onClose}
-                className="px-4 py-2 text-gray-700 bg-gray-100 rounded-md font-medium hover:bg-gray-200"
-              >
-                Done
-              </button>
-            </div>
           </>
         ) : (
           <>
-            <p className="text-gray-600 mb-4">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
               Publishing makes this list publicly viewable. Anyone with the link
               can see the list contents and verify who added each item.
             </p>
 
-            <div className="mb-4 p-3 bg-amber-50 rounded-md">
-              <div className="flex items-start gap-2 text-amber-800">
+            <div className="p-4 bg-amber-50 dark:bg-amber-900/20 rounded-xl">
+              <div className="flex items-start gap-3 text-amber-800 dark:text-amber-400">
                 <svg
                   className="w-5 h-5 mt-0.5 flex-shrink-0"
                   fill="none"
@@ -245,41 +308,26 @@ export function PublishModal({ list, onClose }: PublishModalProps) {
                 </svg>
                 <div>
                   <p className="font-medium">Before you publish</p>
-                  <ul className="mt-1 text-sm list-disc list-inside">
-                    <li>All items will be publicly visible</li>
-                    <li>Contributor names will be shown</li>
-                    <li>The list URL will be shareable</li>
+                  <ul className="mt-2 text-sm space-y-1 text-amber-700 dark:text-amber-500">
+                    <li>• All items will be publicly visible</li>
+                    <li>• Contributor names will be shown</li>
+                    <li>• The list URL will be shareable</li>
                   </ul>
                 </div>
               </div>
             </div>
-
-            {error && (
-              <div className="mb-4 p-3 bg-red-50 rounded-md text-red-600 text-sm">
-                {error}
-              </div>
-            )}
-
-            <div className="flex justify-end gap-3">
-              <button
-                onClick={onClose}
-                className="px-4 py-2 text-gray-700 bg-gray-100 rounded-md font-medium hover:bg-gray-200"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handlePublish}
-                disabled={isPublishing}
-                className={`px-4 py-2 bg-blue-600 text-white rounded-md font-medium hover:bg-blue-700 ${
-                  isPublishing ? "opacity-50 cursor-not-allowed" : ""
-                }`}
-              >
-                {isPublishing ? "Publishing..." : "Publish List"}
-              </button>
-            </div>
           </>
         )}
+
+        {error && (
+          <div className="px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-red-700 dark:text-red-400 text-sm flex items-center gap-2">
+            <svg className="w-5 h-5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            {error}
+          </div>
+        )}
       </div>
-    </div>
+    </Panel>
   );
 }

--- a/src/components/ui/Panel.tsx
+++ b/src/components/ui/Panel.tsx
@@ -1,0 +1,224 @@
+/**
+ * Reusable Panel/Drawer component that slides up from the bottom.
+ * Features:
+ * - Slide-up animation from bottom
+ * - Swipe-to-dismiss gesture support
+ * - Backdrop click to close
+ * - Full-height or auto-height modes
+ * - Mobile-first design that feels native/app-like
+ */
+
+import { useEffect, useRef, useState, useCallback, type ReactNode } from "react";
+import { createPortal } from "react-dom";
+
+interface PanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  title?: string;
+  /** If true, panel takes full height minus safe area */
+  fullHeight?: boolean;
+  /** Show drag handle at top for swipe gesture hint */
+  showHandle?: boolean;
+  /** Custom header content (replaces default title) */
+  header?: ReactNode;
+  /** Footer content (sticky at bottom) */
+  footer?: ReactNode;
+  /** aria-labelledby for accessibility */
+  ariaLabelledBy?: string;
+}
+
+export function Panel({
+  isOpen,
+  onClose,
+  children,
+  title,
+  fullHeight = false,
+  showHandle = true,
+  header,
+  footer,
+  ariaLabelledBy,
+}: PanelProps) {
+  const [isAnimating, setIsAnimating] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const dragState = useRef<{
+    startY: number;
+    startTime: number;
+    currentY: number;
+    isDragging: boolean;
+  } | null>(null);
+
+  // Handle open/close animation
+  useEffect(() => {
+    if (isOpen) {
+      setIsAnimating(true);
+      setIsClosing(false);
+      // Lock body scroll
+      document.body.style.overflow = "hidden";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  // Close with animation
+  const handleClose = useCallback(() => {
+    setIsClosing(true);
+    setTimeout(() => {
+      setIsAnimating(false);
+      setIsClosing(false);
+      onClose();
+    }, 200); // Match animation duration
+  }, [onClose]);
+
+  // Escape key handler
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") handleClose();
+    };
+    if (isOpen) {
+      window.addEventListener("keydown", handleEscape);
+      return () => window.removeEventListener("keydown", handleEscape);
+    }
+  }, [isOpen, handleClose]);
+
+  // Touch handlers for swipe-to-dismiss
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    dragState.current = {
+      startY: touch.clientY,
+      startTime: Date.now(),
+      currentY: touch.clientY,
+      isDragging: false,
+    };
+  }, []);
+
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!dragState.current || !panelRef.current) return;
+
+    const touch = e.touches[0];
+    const deltaY = touch.clientY - dragState.current.startY;
+
+    // Only allow dragging down (positive deltaY)
+    if (deltaY > 10) {
+      dragState.current.isDragging = true;
+      dragState.current.currentY = touch.clientY;
+
+      // Check if content is scrolled to top before allowing drag
+      const content = contentRef.current;
+      if (content && content.scrollTop > 0) {
+        dragState.current.isDragging = false;
+        return;
+      }
+
+      // Apply transform for visual feedback
+      const clampedDelta = Math.min(deltaY, 300);
+      panelRef.current.style.transform = `translateY(${clampedDelta}px)`;
+      panelRef.current.style.transition = "none";
+    }
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    if (!dragState.current || !panelRef.current) return;
+
+    const { startY, startTime, currentY, isDragging } = dragState.current;
+
+    if (isDragging) {
+      const deltaY = currentY - startY;
+      const duration = Date.now() - startTime;
+      const velocity = deltaY / duration;
+
+      // Close if dragged far enough or with enough velocity
+      if (deltaY > 100 || velocity > 0.5) {
+        handleClose();
+      } else {
+        // Snap back
+        panelRef.current.style.transform = "";
+        panelRef.current.style.transition = "transform 0.2s ease-out";
+      }
+    }
+
+    dragState.current = null;
+  }, [handleClose]);
+
+  if (!isOpen && !isAnimating) return null;
+
+  return createPortal(
+    <div
+      className={`fixed inset-0 z-[100] flex flex-col justify-end transition-colors duration-200 ${
+        isClosing ? "bg-black/0" : "bg-black/50"
+      }`}
+      onClick={handleClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={ariaLabelledBy}
+    >
+      <div
+        ref={panelRef}
+        className={`
+          bg-white dark:bg-gray-800 
+          rounded-t-2xl shadow-2xl 
+          w-full 
+          ${fullHeight ? "h-[90vh]" : "max-h-[90vh]"}
+          flex flex-col
+          safe-area-inset-bottom
+          ${isClosing ? "animate-panel-close" : "animate-panel-open"}
+        `}
+        onClick={(e) => e.stopPropagation()}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        {/* Drag Handle */}
+        {showHandle && (
+          <div className="flex justify-center pt-3 pb-1 cursor-grab active:cursor-grabbing">
+            <div className="w-10 h-1 bg-gray-300 dark:bg-gray-600 rounded-full" />
+          </div>
+        )}
+
+        {/* Header */}
+        {(header || title) && (
+          <div className="flex items-center justify-between px-5 py-3 border-b border-gray-200 dark:border-gray-700">
+            {header || (
+              <>
+                <h2
+                  id={ariaLabelledBy}
+                  className="text-lg font-semibold text-gray-900 dark:text-gray-100"
+                >
+                  {title}
+                </h2>
+                <button
+                  onClick={handleClose}
+                  className="p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 rounded-lg transition-colors"
+                  aria-label="Close panel"
+                >
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                  </svg>
+                </button>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Content */}
+        <div
+          ref={contentRef}
+          className="flex-1 overflow-y-auto overscroll-contain"
+        >
+          {children}
+        </div>
+
+        {/* Footer */}
+        {footer && (
+          <div className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -71,6 +71,24 @@
   }
 }
 
+@keyframes panel-open {
+  0% {
+    transform: translateY(100%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes panel-close {
+  0% {
+    transform: translateY(0);
+  }
+  100% {
+    transform: translateY(100%);
+  }
+}
+
 @keyframes slide-in-right {
   0% {
     opacity: 0;
@@ -142,6 +160,14 @@
 
 .animate-pulse-ring {
   animation: pulse-ring 2s ease-in-out infinite;
+}
+
+.animate-panel-open {
+  animation: panel-open 0.3s cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+
+.animate-panel-close {
+  animation: panel-close 0.2s cubic-bezier(0.32, 0.72, 0, 1) forwards;
 }
 
 /* Custom scrollbar */


### PR DESCRIPTION
## Summary
Converts all modals in the app to slide-up panels/drawers for a more native, app-like experience, especially on mobile.

## Changes
- Created reusable `Panel` component (`src/components/ui/Panel.tsx`)
  - Slides up from bottom with smooth animation
  - Supports swipe-to-dismiss gesture
  - Backdrop click to close
  - Keyboard accessible (Escape to close)
  - Optional drag handle for visual affordance
  - Flexible header/footer slots

- Converted all modals to use Panel:
  - `ItemDetailsModal` - Edit item details
  - `Settings` - App settings
  - `TemplatePickerModal` - Choose/create from templates
  - `ShareModal` - Share list with others
  - `CreateListModal` - Create new list
  - `SaveAsTemplateModal` - Save list as template
  - `PublishModal` - Publish list publicly

- Added CSS animations for panel open/close

## Testing
- Build passes ✅
- All panels slide up smoothly
- Swipe down to dismiss works
- Backdrop click to close works
- Escape key closes panel
- Dark mode supported

## Screenshots
Panels now slide up from bottom instead of appearing as centered modals - feels much more native on mobile devices.

Fixes: "Make any modal into a panel or something the modal experience is bad"