### PR TITLE
feat: Add REST API for agent/script access

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,273 @@
+# Poo App Agent API
+
+REST API for programmatic access to Poo App lists and items. Designed for agents, scripts, and integrations to interact without using a browser.
+
+## Base URL
+
+```
+https://<convex-deployment>.convex.site
+```
+
+## Authentication
+
+All endpoints require JWT authentication via the `Authorization` header:
+
+```
+Authorization: Bearer <your-jwt-token>
+```
+
+To obtain a JWT token, use the standard auth flow:
+1. `POST /auth/initiate` with `{ "email": "your@email.com" }`
+2. `POST /auth/verify` with `{ "sessionId": "...", "code": "..." }` (OTP from email)
+3. Use the returned `token` in subsequent requests
+
+## Endpoints
+
+### Lists
+
+#### Get All Lists
+```
+GET /api/agent/lists
+```
+
+Returns all lists the authenticated user has access to.
+
+**Response:**
+```json
+{
+  "lists": [
+    {
+      "_id": "abc123...",
+      "name": "Shopping List",
+      "ownerDid": "did:webvh:...",
+      "createdAt": 1704067200000,
+      "role": "owner"
+    }
+  ]
+}
+```
+
+#### Get List with Items
+```
+GET /api/agent/lists/:listId
+GET /api/agent/lists/:listId/items
+```
+
+Returns a list and all its items.
+
+**Response:**
+```json
+{
+  "list": {
+    "_id": "abc123...",
+    "name": "Shopping List",
+    "ownerDid": "did:webvh:...",
+    "createdAt": 1704067200000,
+    "assetDid": "did:peer:..."
+  },
+  "items": [
+    {
+      "_id": "item123...",
+      "name": "Milk",
+      "checked": false,
+      "createdByDid": "did:webvh:...",
+      "createdAt": 1704067200000,
+      "order": 0,
+      "description": "2% organic",
+      "priority": "high"
+    }
+  ],
+  "role": "owner"
+}
+```
+
+#### Add Item to List
+```
+POST /api/agent/lists/:listId/items
+Content-Type: application/json
+
+{
+  "name": "Buy groceries",
+  "description": "From Whole Foods",
+  "priority": "high",
+  "dueDate": 1704153600000,
+  "url": "https://example.com"
+}
+```
+
+**Response (201 Created):**
+```json
+{
+  "itemId": "item456...",
+  "item": {
+    "_id": "item456...",
+    "name": "Buy groceries",
+    "checked": false,
+    "createdByDid": "did:webvh:...",
+    "description": "From Whole Foods",
+    "priority": "high",
+    "dueDate": 1704153600000,
+    "url": "https://example.com"
+  }
+}
+```
+
+### Items
+
+#### Update Item
+```
+PATCH /api/agent/items/:itemId
+Content-Type: application/json
+
+{
+  "checked": true,
+  "name": "Updated name",
+  "description": "Updated description",
+  "priority": "medium",
+  "dueDate": 1704240000000,
+  "url": "https://new-url.com"
+}
+```
+
+All fields are optional. To clear a field, set it to `null`:
+```json
+{
+  "priority": null,
+  "dueDate": null
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "item": {
+    "_id": "item123...",
+    "name": "Updated name",
+    "checked": true,
+    ...
+  }
+}
+```
+
+#### Delete Item
+```
+DELETE /api/agent/items/:itemId
+```
+
+**Response:**
+```json
+{
+  "success": true
+}
+```
+
+## Field Reference
+
+### Item Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Item title (required for creation) |
+| `description` | string | Optional notes/details |
+| `checked` | boolean | Whether the item is complete |
+| `priority` | "high" \| "medium" \| "low" | Priority level |
+| `dueDate` | number | Unix timestamp in milliseconds |
+| `url` | string | Link to PR, URL, or reference |
+| `order` | number | Position in list (lower = higher) |
+| `createdByDid` | string | DID of user who created the item |
+| `checkedByDid` | string | DID of user who checked the item |
+| `createdAt` | number | Creation timestamp |
+| `checkedAt` | number | When item was checked |
+
+### Roles
+
+| Role | Permissions |
+|------|-------------|
+| `owner` | Full access (read, write, delete, share) |
+| `editor` | Read and write access |
+| `viewer` | Read-only access |
+
+## Error Responses
+
+All errors return JSON with an `error` field:
+
+```json
+{
+  "error": "Error message here"
+}
+```
+
+| Status | Description |
+|--------|-------------|
+| 400 | Bad request (missing/invalid parameters) |
+| 401 | Unauthorized (missing/invalid token) |
+| 403 | Forbidden (no access to resource) |
+| 404 | Not found |
+| 405 | Method not allowed |
+| 500 | Server error |
+
+## Examples
+
+### cURL
+
+```bash
+# Get all lists
+curl -H "Authorization: Bearer $TOKEN" \
+  https://your-deployment.convex.site/api/agent/lists
+
+# Get a specific list with items
+curl -H "Authorization: Bearer $TOKEN" \
+  https://your-deployment.convex.site/api/agent/lists/abc123xyz
+
+# Add an item
+curl -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "New task", "priority": "high"}' \
+  https://your-deployment.convex.site/api/agent/lists/abc123xyz/items
+
+# Check off an item
+curl -X PATCH \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"checked": true}' \
+  https://your-deployment.convex.site/api/agent/items/item123xyz
+
+# Delete an item
+curl -X DELETE \
+  -H "Authorization: Bearer $TOKEN" \
+  https://your-deployment.convex.site/api/agent/items/item123xyz
+```
+
+### JavaScript/TypeScript
+
+```typescript
+const BASE_URL = "https://your-deployment.convex.site";
+const TOKEN = "your-jwt-token";
+
+// Get all lists
+const lists = await fetch(`${BASE_URL}/api/agent/lists`, {
+  headers: { Authorization: `Bearer ${TOKEN}` }
+}).then(r => r.json());
+
+// Add an item
+const newItem = await fetch(`${BASE_URL}/api/agent/lists/${listId}/items`, {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${TOKEN}`,
+    "Content-Type": "application/json"
+  },
+  body: JSON.stringify({ name: "New task", priority: "high" })
+}).then(r => r.json());
+
+// Check off an item
+await fetch(`${BASE_URL}/api/agent/items/${itemId}`, {
+  method: "PATCH",
+  headers: {
+    Authorization: `Bearer ${TOKEN}`,
+    "Content-Type": "application/json"
+  },
+  body: JSON.stringify({ checked: true })
+});
+```

--- a/convex/agentApi.ts
+++ b/convex/agentApi.ts
@@ -1,0 +1,443 @@
+/**
+ * Agent API - HTTP endpoints for programmatic access to Poo App.
+ *
+ * These endpoints allow agents and scripts to interact with the app
+ * without using a browser. All endpoints require JWT authentication.
+ *
+ * Endpoints:
+ * - GET  /api/agent/lists            - Get all lists for the user
+ * - GET  /api/agent/lists/:id        - Get a list with its items
+ * - GET  /api/agent/lists/:id/items  - Get items for a list
+ * - POST /api/agent/lists/:id/items  - Add an item to a list
+ * - PATCH /api/agent/items/:id       - Update an item (check/uncheck/edit)
+ * - DELETE /api/agent/items/:id      - Delete an item
+ */
+
+import { httpAction } from "./_generated/server";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import type { ActionCtx } from "./_generated/server";
+import {
+  requireAuth,
+  AuthError,
+  unauthorizedResponseWithCors,
+} from "./lib/auth";
+import { jsonResponse, errorResponse, getCorsHeaders } from "./lib/httpResponses";
+
+/**
+ * Helper type for user info.
+ */
+type UserInfo = { did: string; legacyDid?: string } | null;
+
+/**
+ * Extract list ID from URL path.
+ * Handles paths like /api/agent/lists/:id or /api/agent/lists/:id/items
+ */
+function extractListIdFromPath(url: string): string | null {
+  const match = url.match(/\/api\/agent\/lists\/([a-z0-9]+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Extract item ID from URL path.
+ * Handles paths like /api/agent/items/:id
+ */
+function extractItemIdFromPath(url: string): string | null {
+  const match = url.match(/\/api\/agent\/items\/([a-z0-9]+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Get user from auth token.
+ */
+async function getAuthenticatedUser(
+  ctx: ActionCtx,
+  request: Request
+): Promise<{ user: NonNullable<UserInfo>; auth: { turnkeySubOrgId: string; email: string } }> {
+  const auth = await requireAuth(request);
+
+  const user = await ctx.runQuery(api.auth.getUserByTurnkeyId, {
+    turnkeySubOrgId: auth.turnkeySubOrgId,
+  }) as UserInfo;
+
+  if (!user) {
+    throw new Error("User not found");
+  }
+
+  return { user, auth };
+}
+
+/**
+ * Handle GET /api/agent/lists/:id - Get a list with all its items.
+ */
+async function handleGetListWithItems(
+  ctx: ActionCtx,
+  request: Request,
+  listIdStr: string
+): Promise<Response> {
+  const { user } = await getAuthenticatedUser(ctx, request);
+  const listId = listIdStr as Id<"lists">;
+
+  // Get the list
+  const list = await ctx.runQuery(api.lists.getList, { listId });
+  if (!list) {
+    return errorResponse(request, "List not found", 404);
+  }
+
+  // Check if user has access (via collaborators table)
+  const collaborators = await ctx.runQuery(api.collaborators.getListCollaborators, { listId });
+  const userCollab = collaborators.find(
+    (c: { userDid: string }) => c.userDid === user.did || c.userDid === user.legacyDid
+  );
+
+  // Also check legacy ownerDid
+  const isLegacyOwner = list.ownerDid === user.did || list.ownerDid === user.legacyDid;
+
+  if (!userCollab && !isLegacyOwner) {
+    return errorResponse(request, "Access denied", 403);
+  }
+
+  const role = userCollab?.role ?? (isLegacyOwner ? "owner" : "viewer");
+
+  // Get items for the list
+  const items = await ctx.runQuery(api.items.getListItems, { listId });
+
+  return jsonResponse(request, {
+    list: {
+      _id: list._id,
+      name: list.name,
+      ownerDid: list.ownerDid,
+      createdAt: list.createdAt,
+      assetDid: list.assetDid,
+    },
+    items: items.map((item: {
+      _id: Id<"items">;
+      name: string;
+      checked: boolean;
+      createdByDid: string;
+      checkedByDid?: string;
+      createdAt: number;
+      checkedAt?: number;
+      order?: number;
+      description?: string;
+      dueDate?: number;
+      url?: string;
+      priority?: "high" | "medium" | "low";
+    }) => ({
+      _id: item._id,
+      name: item.name,
+      checked: item.checked,
+      createdByDid: item.createdByDid,
+      checkedByDid: item.checkedByDid,
+      createdAt: item.createdAt,
+      checkedAt: item.checkedAt,
+      order: item.order,
+      description: item.description,
+      dueDate: item.dueDate,
+      url: item.url,
+      priority: item.priority,
+    })),
+    role,
+  });
+}
+
+/**
+ * Handle POST /api/agent/lists/:id/items - Add an item to a list.
+ */
+async function handleAddItemToList(
+  ctx: ActionCtx,
+  request: Request,
+  listIdStr: string
+): Promise<Response> {
+  const { user } = await getAuthenticatedUser(ctx, request);
+
+  // Parse request body
+  const body = await request.json();
+  const { name, description, priority, dueDate, url: itemUrl } = body as {
+    name: string;
+    description?: string;
+    priority?: "high" | "medium" | "low";
+    dueDate?: number;
+    url?: string;
+  };
+
+  if (!name) {
+    return errorResponse(request, "Item name is required", 400);
+  }
+
+  const listId = listIdStr as Id<"lists">;
+
+  // Call the mutation with server-verified DID
+  const itemId = await ctx.runMutation(api.items.addItem, {
+    listId,
+    name,
+    createdByDid: user.did,
+    legacyDid: user.legacyDid,
+    createdAt: Date.now(),
+    description,
+    priority,
+    dueDate,
+    url: itemUrl,
+  });
+
+  return jsonResponse(request, {
+    itemId,
+    item: {
+      _id: itemId,
+      name,
+      checked: false,
+      createdByDid: user.did,
+      description,
+      priority,
+      dueDate,
+      url: itemUrl,
+    },
+  }, 201);
+}
+
+/**
+ * Handle PATCH /api/agent/items/:id - Update an item.
+ */
+async function handleUpdateItem(
+  ctx: ActionCtx,
+  request: Request,
+  itemIdStr: string
+): Promise<Response> {
+  const { user } = await getAuthenticatedUser(ctx, request);
+  const itemId = itemIdStr as Id<"items">;
+
+  // Parse request body
+  const body = await request.json();
+  const { checked, name, description, priority, dueDate, url: itemUrl } = body as {
+    checked?: boolean;
+    name?: string;
+    description?: string;
+    priority?: "high" | "medium" | "low" | null;
+    dueDate?: number | null;
+    url?: string | null;
+  };
+
+  // Handle checked state change
+  if (checked === true) {
+    await ctx.runMutation(api.items.checkItem, {
+      itemId,
+      checkedByDid: user.did,
+      legacyDid: user.legacyDid,
+      checkedAt: Date.now(),
+    });
+  } else if (checked === false) {
+    await ctx.runMutation(api.items.uncheckItem, {
+      itemId,
+      userDid: user.did,
+      legacyDid: user.legacyDid,
+    });
+  }
+
+  // Handle other updates
+  if (name !== undefined || description !== undefined || priority !== undefined || dueDate !== undefined || itemUrl !== undefined) {
+    await ctx.runMutation(api.items.updateItem, {
+      itemId,
+      userDid: user.did,
+      legacyDid: user.legacyDid,
+      name,
+      description,
+      priority: priority === null ? undefined : priority,
+      dueDate: dueDate === null ? undefined : dueDate,
+      url: itemUrl === null ? undefined : itemUrl,
+      clearPriority: priority === null,
+      clearDueDate: dueDate === null,
+      clearUrl: itemUrl === null,
+    });
+  }
+
+  // Get updated item
+  const updatedItem = await ctx.runQuery(api.items.getItemForSync, { itemId });
+
+  return jsonResponse(request, {
+    success: true,
+    item: updatedItem,
+  });
+}
+
+/**
+ * Handle DELETE /api/agent/items/:id - Delete an item.
+ */
+async function handleDeleteItem(
+  ctx: ActionCtx,
+  request: Request,
+  itemIdStr: string
+): Promise<Response> {
+  const { user } = await getAuthenticatedUser(ctx, request);
+  const itemId = itemIdStr as Id<"items">;
+
+  // Call the mutation with server-verified DID
+  await ctx.runMutation(api.items.removeItem, {
+    itemId,
+    userDid: user.did,
+    legacyDid: user.legacyDid,
+  });
+
+  return jsonResponse(request, { success: true });
+}
+
+/**
+ * Handle GET /api/agent/lists - Get all lists for the user.
+ */
+async function handleGetUserLists(
+  ctx: ActionCtx,
+  request: Request
+): Promise<Response> {
+  const { user } = await getAuthenticatedUser(ctx, request);
+
+  // Get all lists for the user
+  const lists = await ctx.runQuery(api.lists.getUserLists, {
+    userDid: user.did,
+    legacyDid: user.legacyDid,
+  });
+
+  // Get roles for each list
+  const listsWithRoles = await Promise.all(
+    lists.map(async (list: { _id: Id<"lists">; name: string; ownerDid: string; createdAt: number; assetDid: string }) => {
+      const collaborators = await ctx.runQuery(api.collaborators.getListCollaborators, { listId: list._id });
+      const userCollab = collaborators.find(
+        (c: { userDid: string }) => c.userDid === user.did || c.userDid === user.legacyDid
+      );
+      const isLegacyOwner = list.ownerDid === user.did || list.ownerDid === user.legacyDid;
+      const role = userCollab?.role ?? (isLegacyOwner ? "owner" : "viewer");
+
+      return {
+        _id: list._id,
+        name: list.name,
+        ownerDid: list.ownerDid,
+        createdAt: list.createdAt,
+        role,
+      };
+    })
+  );
+
+  return jsonResponse(request, { lists: listsWithRoles });
+}
+
+// ============================================================================
+// Exported HTTP Actions
+// ============================================================================
+
+/**
+ * GET /api/agent/lists
+ *
+ * Get all lists the authenticated user has access to.
+ */
+export const getUserLists = httpAction(async (ctx, request) => {
+  try {
+    return await handleGetUserLists(ctx, request);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return unauthorizedResponseWithCors(request, error.message);
+    }
+    console.error("[agentApi] getUserLists error:", error);
+    return errorResponse(
+      request,
+      error instanceof Error ? error.message : "Failed to get lists",
+      500
+    );
+  }
+});
+
+/**
+ * Router for /api/agent/lists/:id and /api/agent/lists/:id/items
+ *
+ * Handles:
+ * - GET /api/agent/lists/:id - Get a specific list with items
+ * - GET /api/agent/lists/:id/items - Get items for a list
+ * - POST /api/agent/lists/:id/items - Add item to a list
+ */
+export const agentListHandler = httpAction(async (ctx, request) => {
+  try {
+    const url = new URL(request.url);
+    const path = url.pathname;
+
+    // Extract list ID
+    const listIdStr = extractListIdFromPath(path);
+    if (!listIdStr) {
+      return errorResponse(request, "List ID is required", 400);
+    }
+
+    // Check if this is the /items endpoint
+    const isItemsEndpoint = path.endsWith("/items");
+
+    if (request.method === "GET") {
+      // Both /lists/:id and /lists/:id/items return the same data
+      return await handleGetListWithItems(ctx, request, listIdStr);
+    }
+
+    if (request.method === "POST" && isItemsEndpoint) {
+      return await handleAddItemToList(ctx, request, listIdStr);
+    }
+
+    return errorResponse(request, "Method not allowed", 405);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return unauthorizedResponseWithCors(request, error.message);
+    }
+    console.error("[agentApi] agentListHandler error:", error);
+    return errorResponse(
+      request,
+      error instanceof Error ? error.message : "Request failed",
+      500
+    );
+  }
+});
+
+/**
+ * Router for /api/agent/items/:id
+ *
+ * Handles:
+ * - PATCH /api/agent/items/:id - Update an item
+ * - DELETE /api/agent/items/:id - Delete an item
+ */
+export const agentItemHandler = httpAction(async (ctx, request) => {
+  try {
+    const url = new URL(request.url);
+    const path = url.pathname;
+
+    // Extract item ID
+    const itemIdStr = extractItemIdFromPath(path);
+    if (!itemIdStr) {
+      return errorResponse(request, "Item ID is required", 400);
+    }
+
+    if (request.method === "PATCH") {
+      return await handleUpdateItem(ctx, request, itemIdStr);
+    }
+
+    if (request.method === "DELETE") {
+      return await handleDeleteItem(ctx, request, itemIdStr);
+    }
+
+    return errorResponse(request, "Method not allowed", 405);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return unauthorizedResponseWithCors(request, error.message);
+    }
+    console.error("[agentApi] agentItemHandler error:", error);
+    return errorResponse(
+      request,
+      error instanceof Error ? error.message : "Request failed",
+      500
+    );
+  }
+});
+
+/**
+ * CORS preflight handler for agent API.
+ */
+export const corsHandler = httpAction(async (_ctx, request) => {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      ...getCorsHeaders(request),
+      "Access-Control-Allow-Methods": "GET, POST, PATCH, DELETE, OPTIONS",
+      "Access-Control-Max-Age": "86400",
+    },
+  });
+});

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -27,6 +27,12 @@ import {
   removeCollaborator,
 } from "./collaboratorsHttp";
 import { updateUserDID } from "./userHttp";
+import {
+  getUserLists as agentGetUserLists,
+  agentListHandler,
+  agentItemHandler,
+  corsHandler as agentCorsHandler,
+} from "./agentApi";
 
 // Rate limit configuration
 const RATE_LIMITS = {
@@ -388,5 +394,31 @@ http.route({ path: "/api/collaborators/remove", method: "OPTIONS", handler: cors
 // --- User endpoints ---
 http.route({ path: "/api/user/updateDID", method: "POST", handler: updateUserDID });
 http.route({ path: "/api/user/updateDID", method: "OPTIONS", handler: corsHandler });
+
+// ============================================================================
+// Agent API endpoints (RESTful API for programmatic access)
+// All endpoints require JWT authentication via Authorization header.
+// ============================================================================
+
+// --- Agent List endpoints ---
+// GET /api/agent/lists - Get all lists for the authenticated user
+http.route({ path: "/api/agent/lists", method: "GET", handler: agentGetUserLists });
+http.route({ path: "/api/agent/lists", method: "OPTIONS", handler: agentCorsHandler });
+
+// Note: Convex httpRouter doesn't support path parameters like :id
+// So we use prefix matching and parse the ID in the handler
+
+// GET  /api/agent/lists/:id        - Get a specific list with items
+// GET  /api/agent/lists/:id/items  - Get items for a list  
+// POST /api/agent/lists/:id/items  - Add item to a list
+http.route({ pathPrefix: "/api/agent/lists/", method: "GET", handler: agentListHandler });
+http.route({ pathPrefix: "/api/agent/lists/", method: "POST", handler: agentListHandler });
+http.route({ pathPrefix: "/api/agent/lists/", method: "OPTIONS", handler: agentCorsHandler });
+
+// PATCH  /api/agent/items/:id - Update an item (check/uncheck/edit)
+// DELETE /api/agent/items/:id - Delete an item
+http.route({ pathPrefix: "/api/agent/items/", method: "PATCH", handler: agentItemHandler });
+http.route({ pathPrefix: "/api/agent/items/", method: "DELETE", handler: agentItemHandler });
+http.route({ pathPrefix: "/api/agent/items/", method: "OPTIONS", handler: agentCorsHandler });
 
 export default http;


### PR DESCRIPTION
## Summary

Adds new HTTP endpoints for programmatic access to Poo App, allowing agents and scripts to interact without using a browser.

## New Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/agent/lists` | List all user's lists |
| GET | `/api/agent/lists/:id` | Get list with items |
| POST | `/api/agent/lists/:id/items` | Add item to list |
| PATCH | `/api/agent/items/:id` | Update item (check/uncheck/edit) |
| DELETE | `/api/agent/items/:id` | Delete item |

All endpoints require JWT authentication via the `Authorization: Bearer <token>` header.

## Files Changed

- `convex/agentApi.ts` - New agent API handlers
- `convex/http.ts` - Route registration
- `API.md` - Full API documentation with examples

## Testing

- [x] `bun run build` passes
- [ ] Manual testing with cURL (can be done after merge)

## Closes

Make nice api so agents can interact without using browser