### PR TITLE
feat: Issue Verifiable Credential when list is created

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -87,6 +87,8 @@ export default defineSchema({
     ownerDid: v.string(), // Creator's DID
     categoryId: v.optional(v.id("categories")), // User's category for this list (Phase 2)
     createdAt: v.number(),
+    // Verifiable Credential proof of ownership (Phase: VC)
+    vcProof: v.optional(v.string()), // JSON-encoded VC proving list ownership
   })
     .index("by_owner", ["ownerDid"])
     .index("by_asset_did", ["assetDid"])


### PR DESCRIPTION
## Summary
Issue a Verifiable Credential when a list is created that proves ownership.

## Changes
- **schema.ts**: Added optional `vcProof` field to lists table
- **lists.ts**: Added `createListOwnershipVC` function and integrated into `createList` mutation

## Implementation Details
The VC follows W3C VC Data Model structure:
```json
{
  "@context": ["https://www.w3.org/2018/credentials/v1", "https://originals.tech/credentials/v1"],
  "type": ["VerifiableCredential", "ListOwnershipCredential"],
  "issuer": "<ownerDid>",
  "credentialSubject": {
    "id": "<ownerDid>",
    "listId": "...",
    "assetDid": "...",
    "role": "owner"
  },
  "proof": { "type": "PlaceholderProof2024", ... }
}
```

## Future Enhancements
The placeholder proof can be replaced with cryptographic signature when server-side signing via Turnkey or @originals/sdk CredentialManager is implemented.

## Testing
- `bun run build` passes ✅