### PR TITLE
feat: Issue VCs for item creation and completion

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -120,6 +120,9 @@ export default defineSchema({
     parentId: v.optional(v.id("items")),
     // Attachments - stored file IDs
     attachments: v.optional(v.array(v.id("_storage"))),
+    // Verifiable Credential proofs (Phase: VC)
+    // Array of JSON-encoded VCs proving item authorship and completion
+    vcProofs: v.optional(v.array(v.string())),
   })
     .index("by_list", ["listId"])
     .index("by_parent", ["parentId"])


### PR DESCRIPTION
## Summary
This PR adds Verifiable Credential issuance for item creation and completion, providing authorship proof for todo items.

## Changes
- **schema.ts**: Add `vcProofs` optional array field to items table
- **items.ts**: 
  - Add `createItemAuthorshipVC()` function for item creation proof
  - Add `createItemCompletionVC()` function for item completion proof
  - Modify `addItem` mutation to issue authorship VC after item creation
  - Modify `checkItem` mutation to append completion VC when item is checked

## VC Structure
Follows W3C VC Data Model with placeholder proofs (same pattern as PR #45):

### ItemAuthorshipCredential
```json
{
  "@context": [...],
  "type": ["VerifiableCredential", "ItemAuthorshipCredential"],
  "credentialSubject": {
    "id": "<creatorDid>",
    "itemId": "...",
    "listId": "...",
    "itemName": "...",
    "action": "created",
    "createdAt": "..."
  }
}
```

### ItemCompletionCredential
```json
{
  "@context": [...],
  "type": ["VerifiableCredential", "ItemCompletionCredential"],
  "credentialSubject": {
    "id": "<completerDid>",
    "itemId": "...",
    "listId": "...",
    "itemName": "...",
    "action": "completed",
    "completedAt": "..."
  }
}
```

## Testing
- ✅ `bun run build` passes