### PR TITLE
fix: Mobile UI truncation issues

### DIFF
--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -50,23 +50,23 @@ export function ListCard({ list, currentUserDid, showOwner }: ListCardProps) {
     <Link
       to={`/list/${list._id}`}
       onClick={() => haptic('light')}
-      className="group block bg-white dark:bg-gray-800 rounded-2xl shadow-lg hover:shadow-xl dark:shadow-gray-900/50 transition-all duration-200 p-5 card-hover border border-gray-100 dark:border-gray-700 hover:border-amber-200 dark:hover:border-amber-600"
+      className="group block bg-white dark:bg-gray-800 rounded-2xl shadow-lg hover:shadow-xl dark:shadow-gray-900/50 transition-all duration-200 p-4 sm:p-5 card-hover border border-gray-100 dark:border-gray-700 hover:border-amber-200 dark:hover:border-amber-600"
     >
-      <div className="flex items-start gap-4">
-        {/* Emoji icon */}
-        <div className="flex-shrink-0 w-12 h-12 bg-gradient-to-br from-amber-100 to-orange-100 dark:from-amber-900/30 dark:to-orange-900/30 rounded-xl flex items-center justify-center text-2xl group-hover:scale-110 transition-transform">
+      <div className="flex items-start gap-3 sm:gap-4">
+        {/* Emoji icon - smaller on mobile */}
+        <div className="flex-shrink-0 w-10 h-10 sm:w-12 sm:h-12 bg-gradient-to-br from-amber-100 to-orange-100 dark:from-amber-900/30 dark:to-orange-900/30 rounded-xl flex items-center justify-center text-xl sm:text-2xl group-hover:scale-110 transition-transform">
           {emoji}
         </div>
 
         <div className="flex-1 min-w-0">
           {/* List name and badges */}
           <div className="flex items-start justify-between gap-2">
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors">
+            <h3 className="text-base sm:text-lg font-semibold text-gray-900 dark:text-gray-100 group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors line-clamp-2 sm:truncate">
               {list.name}
             </h3>
             {!isOwner && (
-              <span className="flex-shrink-0 inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold bg-gradient-to-r from-green-100 to-emerald-100 dark:from-green-900/30 dark:to-emerald-900/30 text-green-700 dark:text-green-400 border border-green-200 dark:border-green-800">
-                <svg className="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <span className="flex-shrink-0 inline-flex items-center px-2 sm:px-2.5 py-0.5 sm:py-1 rounded-full text-[10px] sm:text-xs font-semibold bg-gradient-to-r from-green-100 to-emerald-100 dark:from-green-900/30 dark:to-emerald-900/30 text-green-700 dark:text-green-400 border border-green-200 dark:border-green-800">
+                <svg className="w-3 h-3 mr-0.5 sm:mr-1 hidden sm:block" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
                 </svg>
                 Shared

--- a/src/components/ProfileBadge.tsx
+++ b/src/components/ProfileBadge.tsx
@@ -22,7 +22,24 @@ export function ProfileBadge() {
 
   return (
     <div className="flex items-center gap-2">
-      {/* DID badge - now links to profile */}
+      {/* DID badge - links to profile, responsive display */}
+      {/* Mobile: show icon only */}
+      <Link 
+        to="/profile"
+        onClick={() => haptic('light')}
+        className="flex sm:hidden items-center justify-center w-9 h-9 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-full transition-colors"
+        title={did}
+        aria-label="View profile"
+      >
+        <div className="relative">
+          <svg className="w-5 h-5 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+          </svg>
+          <div className="absolute -bottom-0.5 -right-0.5 w-2.5 h-2.5 bg-green-500 rounded-full border-2 border-white dark:border-gray-800" />
+        </div>
+      </Link>
+      
+      {/* Desktop: show DID badge */}
       <Link 
         to="/profile"
         onClick={() => haptic('light')}

--- a/src/pages/ListView.tsx
+++ b/src/pages/ListView.tsx
@@ -500,29 +500,34 @@ export function ListView() {
   return (
     <div className="max-w-3xl mx-auto">
       {/* Header - Redesigned for less crowding */}
-      <div className="flex items-center gap-3 mb-6">
-        {/* Back button */}
-        <Link
-          to="/app"
-          onClick={() => haptic('light')}
-          className="flex-shrink-0 w-10 h-10 flex items-center justify-center text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl transition-colors"
-          aria-label="Back to lists"
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-          </svg>
-        </Link>
+      {/* Mobile: stack title above actions for more room */}
+      <div className="mb-6">
+        {/* Top row: back button + title */}
+        <div className="flex items-center gap-2 mb-2">
+          {/* Back button */}
+          <Link
+            to="/app"
+            onClick={() => haptic('light')}
+            className="flex-shrink-0 w-9 h-9 sm:w-10 sm:h-10 flex items-center justify-center text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl transition-colors"
+            aria-label="Back to lists"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+          </Link>
 
-        {/* Title and info - takes remaining space */}
-        <div className="flex-1 min-w-0">
-          <h2 className="text-lg sm:text-xl font-bold text-gray-900 dark:text-gray-100 truncate">
+          {/* Title - allow more characters on mobile with line-clamp-2 */}
+          <h2 className="flex-1 min-w-0 text-lg sm:text-xl font-bold text-gray-900 dark:text-gray-100 line-clamp-2 sm:truncate">
             {list.name}
           </h2>
-          
+        </div>
+        
+        {/* Bottom row: progress info + action buttons */}
+        <div className="flex items-center justify-between gap-2 pl-11 sm:pl-12">
           {/* Progress and collaborators info */}
-          <div className="flex items-center gap-2 text-xs sm:text-sm">
+          <div className="flex items-center gap-2 text-xs sm:text-sm min-w-0">
             {totalCount > 0 && (
-              <span className="text-gray-500 dark:text-gray-400">
+              <span className="text-gray-500 dark:text-gray-400 whitespace-nowrap">
                 {checkedCount}/{totalCount} done
               </span>
             )}
@@ -553,10 +558,9 @@ export function ListView() {
               </>
             )}
           </div>
-        </div>
 
-        {/* Compact action buttons */}
-        <div className="flex items-center gap-1.5 flex-shrink-0">
+          {/* Compact action buttons */}
+          <div className="flex items-center gap-1.5 flex-shrink-0">
           {/* View toggle - compact on mobile */}
           <div className="flex items-center bg-gray-100 dark:bg-gray-700 rounded-lg p-0.5">
             <button
@@ -627,6 +631,7 @@ export function ListView() {
             onKeyboardShortcuts={() => setShowHelp(true)}
             haptic={haptic}
           />
+        </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Fixes 3 mobile UI issues where text was being truncated too aggressively on small screens (375px viewport):

### Changes

1. **ProfileBadge (DID in navbar)**: Instead of hiding the DID on mobile and showing nothing, now shows a profile icon with a green status indicator. Clicking it still navigates to the profile page.

2. **ListCard (home page list names)**: 
   - Uses `line-clamp-2` on mobile to allow names to wrap to 2 lines instead of aggressive single-line truncation
   - Reduced icon size from 48px to 40px on mobile
   - Reduced padding and badge size on mobile for more text room

3. **ListView header (calendar view title)**:
   - Restructured header layout: title row stacked above action buttons on mobile
   - Uses `line-clamp-2` for list title on mobile instead of single-line truncate
   - Progress info and action buttons now on a separate row below the title

### Testing
- Build passes (`bun run build`)
- All changes use Tailwind responsive breakpoints (sm: 640px)
- Tested components render correctly with longer text