### PR TITLE
fix: Mobile UI truncation - use line-clamp-2 for better text display

### DIFF
--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -63,7 +63,7 @@ export function ListCard({ list, currentUserDid, showOwner }: ListCardProps) {
           {/* List name and badges */}
           <div className="flex items-start justify-between gap-2">
             <div className="flex items-center gap-2 min-w-0">
-              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 truncate group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors">
+              <h3 className="text-base sm:text-lg font-semibold text-gray-900 dark:text-gray-100 line-clamp-2 sm:truncate group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors">
                 {list.name}
               </h3>
               {/* Verification badge showing VC status */}

--- a/src/pages/ListView.tsx
+++ b/src/pages/ListView.tsx
@@ -517,7 +517,7 @@ export function ListView() {
         {/* Title and info - takes remaining space */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <h2 className="text-lg sm:text-xl font-bold text-gray-900 dark:text-gray-100 truncate">
+            <h2 className="text-lg sm:text-xl font-bold text-gray-900 dark:text-gray-100 line-clamp-2 sm:truncate">
               {list.name}
             </h2>
             {/* Verification badge for list */}


### PR DESCRIPTION
Fixes aggressive text truncation on mobile screens:

- ListCard.tsx: List names now show 2 lines on mobile instead of truncating to 'MegaETH Lau...'
- ListView.tsx: List header title uses same treatment, no more 'P.' truncation

Uses Tailwind's line-clamp-2 on mobile, regular truncate on desktop (sm:truncate).