### PR TITLE
Rebrand Poo App to boop

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -26,7 +26,7 @@ async function gotoHome(
   await mockConvexWebSocket(page, { existingListCount });
   await seedAuthSession(page);
   await page.goto("/app");
-  await expect(page.getByRole("heading", { name: "Your Lists" })).toBeVisible({
+  await expect(page.getByRole("heading", { name: /Your lists|Welcome in/i })).toBeVisible({
     timeout: 10000,
   });
 }
@@ -58,7 +58,7 @@ test.describe("Accessibility — Home page", () => {
   test("empty state heading is present for screen readers", async ({ page }) => {
     await gotoHome(page, 0);
 
-    await expect(page.getByRole("heading", { name: "No lists yet!" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Nothing here yet." })).toBeVisible();
   });
 
   test("list cards have aria-labels when lists exist", async ({ page }) => {
@@ -150,7 +150,7 @@ test.describe("Accessibility — Create list modal", () => {
   test("modal has dialog role and labelled input", async ({ page }) => {
     await gotoHome(page, 0);
 
-    await page.getByRole("button", { name: /New list/ }).click();
+    await page.getByRole("button", { name: "Create new list" }).click();
 
     // Template picker appears first
     await expect(
@@ -171,7 +171,7 @@ test.describe("Accessibility — Create list modal", () => {
   test("modal can be dismissed with Escape key", async ({ page }) => {
     await gotoHome(page, 0);
 
-    await page.getByRole("button", { name: /New list/ }).click();
+    await page.getByRole("button", { name: "Create new list" }).click();
     await expect(
       page.getByRole("heading", { name: "Choose a Template" }),
     ).toBeVisible({ timeout: 5000 });

--- a/e2e/delete-list.spec.ts
+++ b/e2e/delete-list.spec.ts
@@ -97,7 +97,7 @@ test.describe("Delete list flow", () => {
     // After onDeleted() is called, the app navigates to /app
     await expect(page).toHaveURL("/app", { timeout: 10000 });
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });
   });
 });

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -36,6 +36,9 @@ export async function seedAuthSession(page: Page, user?: Partial<SeededAuthUser>
     localStorage.setItem("lisa-jwt-token", jwt);
     // Suppress the OnboardingFlow overlay (shown to new users with no lists).
     localStorage.setItem("poo_onboarding_v1", "done");
+    // Dismiss the cookie-consent banner, which otherwise intercepts pointer events
+    // over the FAB in the bottom-right corner.
+    localStorage.setItem("poo-cookie-consent", "accepted");
     // Signal originals.ts to use the E2E stub instead of making real DID SDK calls.
     (window as unknown as Record<string, unknown>).__E2E_MOCK_ORIGINALS = true;
   }, { state: authState, jwt: token });

--- a/e2e/identity.spec.ts
+++ b/e2e/identity.spec.ts
@@ -20,9 +20,8 @@ test.describe("Authentication / Identity flow", () => {
 
   test("login page shows email OTP form", async ({ page }) => {
     await page.goto("/login");
-    await expect(
-      page.getByRole("heading", { name: "Welcome to Poo App" }),
-    ).toBeVisible();
+    // Login page shows the boop wordmark and the email OTP form.
+    await expect(page.getByLabel("boop")).toBeVisible();
     await expect(page.getByPlaceholder("you@example.com")).toBeVisible();
     await expect(
       page.getByRole("button", { name: /Send Code/i }),
@@ -44,7 +43,7 @@ test.describe("Authentication / Identity flow", () => {
 
     // Confirm we landed on the authenticated home page
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });
 
     // Reload — localStorage still has the JWT so no redirect to /login
@@ -52,7 +51,7 @@ test.describe("Authentication / Identity flow", () => {
 
     await expect(page).toHaveURL("/app");
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });
   });
 });

--- a/e2e/items.spec.ts
+++ b/e2e/items.spec.ts
@@ -32,7 +32,7 @@ test.describe("Item management", () => {
 
     await expect(page.getByText("This list is empty")).toBeVisible();
     await expect(
-      page.getByText("Add your first item below to get started!"),
+      page.getByText("Add your first item below to get started."),
     ).toBeVisible();
   });
 
@@ -40,7 +40,7 @@ test.describe("Item management", () => {
     await gotoListPage(page, []);
 
     await page.getByPlaceholder("Add item...").fill("Milk");
-    await page.getByRole("button", { name: "Add" }).click();
+    await page.getByRole("button", { name: "Add", exact: true }).click();
 
     // Optimistic update — item appears immediately without a server round-trip
     await expect(page.getByText("Milk")).toBeVisible({ timeout: 5000 });
@@ -91,7 +91,7 @@ test.describe("Item management", () => {
     await page.getByRole("link", { name: "Back to lists" }).click();
 
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });
   });
 });

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -13,10 +13,8 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Landing page", () => {
-  test("1. page loads with boop wordmark in nav and hero", async ({ page }) => {
+  test("1. page loads with boop hero heading", async ({ page }) => {
     await page.goto("/");
-    // Wordmark in nav
-    await expect(page.getByRole("navigation").getByText("boop").first()).toBeVisible();
     // Hero heading "boop."
     await expect(page.getByRole("heading", { level: 1, name: /boop\./ })).toBeVisible();
     // Hero subtitle (partial match on a distinctive phrase)
@@ -31,9 +29,9 @@ test.describe("Landing page", () => {
     await expect(page).toHaveURL("/login");
   });
 
-  test("3. nav Sign in link navigates to /login", async ({ page }) => {
+  test("3. hero 'Already using boop? Sign in' link navigates to /login", async ({ page }) => {
     await page.goto("/");
-    await page.getByRole("navigation").getByRole("link", { name: "Sign in" }).click();
+    await page.locator(".hero-signin").getByRole("link", { name: "Sign in" }).click();
     await expect(page).toHaveURL("/login");
   });
 

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -1,119 +1,95 @@
 /**
- * Landing page tests (POO-26 / POO-50)
+ * Landing page tests.
  *
  * Covers:
- *   - Branding and tagline render correctly
- *   - No fake stats / fabricated user counts visible
- *   - OG image meta tag set to /og-image.png (POO-50)
- *   - Footer links all present and navigable
- *   - Nav Pricing link works
- *   - Waitlist email form present
- *   - No fake testimonials
+ *   - Boop branding (wordmark + hero) renders
+ *   - Primary CTAs navigate to /login for unauthenticated users
+ *   - "How it works", pricing, and FAQ sections render
+ *   - Footer Privacy link navigates to /privacy
+ *   - OG image meta tag is set to /og-image.png
+ *   - No fabricated user-count stats or "loved by" testimonials
  */
 
 import { test, expect } from "@playwright/test";
 
 test.describe("Landing page", () => {
-  test("1. page loads with Poo App branding and tagline", async ({ page }) => {
+  test("1. page loads with boop wordmark in nav and hero", async ({ page }) => {
     await page.goto("/");
-    // Brand name visible
-    await expect(page.getByText("Poo App").first()).toBeVisible();
-    // Hero tagline
-    await expect(page.getByRole("heading", { name: /Organize your life/i })).toBeVisible();
-    await expect(page.getByText(/while you Poop/i).first()).toBeVisible();
+    // Wordmark in nav
+    await expect(page.getByRole("navigation").getByText("boop").first()).toBeVisible();
+    // Hero heading "boop."
+    await expect(page.getByRole("heading", { level: 1, name: /boop\./ })).toBeVisible();
+    // Hero subtitle (partial match on a distinctive phrase)
+    await expect(
+      page.getByText(/calm little place for the things you need to do/i),
+    ).toBeVisible();
   });
 
-  test("2. nav Pricing link is present", async ({ page }) => {
+  test("2. primary hero CTA navigates unauthenticated users to /login", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByRole("navigation").getByRole("link", { name: "Pricing" })).toBeVisible();
-  });
-
-  test("3. nav Pricing link navigates to /pricing", async ({ page }) => {
-    await page.goto("/");
-    await page.getByRole("navigation").getByRole("link", { name: "Pricing" }).click();
-    await expect(page).toHaveURL("/pricing");
-  });
-
-  test("4. Sign In button navigates to /login for unauthenticated users", async ({ page }) => {
-    await page.goto("/");
-    await page.getByRole("navigation").getByRole("link", { name: "Sign In" }).click();
+    await page.getByRole("link", { name: /Get boop — free/i }).click();
     await expect(page).toHaveURL("/login");
   });
 
-  test("5. Get Started Free CTA navigates to /login for unauthenticated users", async ({ page }) => {
+  test("3. nav Sign in link navigates to /login", async ({ page }) => {
     await page.goto("/");
-    await page.getByRole("link", { name: "Get Started Free" }).click();
+    await page.getByRole("navigation").getByRole("link", { name: "Sign in" }).click();
     await expect(page).toHaveURL("/login");
   });
 
-  test("6. OG image meta tag points to /og-image.png (POO-50)", async ({ page }) => {
+  test("4. how-it-works section lists the three features", async ({ page }) => {
     await page.goto("/");
-    // og:image must be set
-    const ogImage = page.locator('meta[property="og:image"]');
-    await expect(ogImage).toHaveAttribute("content", /\/og-image\.png/);
-    // twitter:image also set
-    const twitterImage = page.locator('meta[name="twitter:image"]');
-    await expect(twitterImage).toHaveAttribute("content", /\/og-image\.png/);
+    await expect(page.getByRole("heading", { name: "Write it down." })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Share, carefully." })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Boop it." })).toBeVisible();
   });
 
-  test("7. no fabricated user count stats visible", async ({ page }) => {
+  test("5. pricing section shows Personal, Shared, and Team plans", async ({ page }) => {
     await page.goto("/");
-    // The landing page MUST NOT show fake user counts like "10,000 users" or "4.9 stars"
-    const pageContent = await page.content();
-    expect(pageContent).not.toMatch(/\b\d[\d,]+\+?\s*(users|customers|downloads|reviews|ratings)\b/i);
+    // Scroll the pricing section into view to avoid lazy-rendered assertions being flaky
+    await page.locator("#pricing").scrollIntoViewIfNeeded();
+    const pricing = page.locator("#pricing");
+    await expect(pricing.getByText("Personal", { exact: true }).first()).toBeVisible();
+    await expect(pricing.getByText("Shared", { exact: true }).first()).toBeVisible();
+    await expect(pricing.getByText("Team", { exact: true }).first()).toBeVisible();
   });
 
-  test("8. no testimonials section", async ({ page }) => {
+  test("6. FAQ section is present", async ({ page }) => {
     await page.goto("/");
-    // Testimonials would be a recognizable heading or attribution pattern
-    await expect(page.getByRole("heading", { name: /testimonial/i })).not.toBeVisible();
-    await expect(page.getByRole("heading", { name: /what.*say/i })).not.toBeVisible();
-    await expect(page.getByRole("heading", { name: /loved by/i })).not.toBeVisible();
+    await page.locator("#faq").scrollIntoViewIfNeeded();
+    await expect(page.getByRole("heading", { name: "Just the honest questions." })).toBeVisible();
   });
 
-  test("9. footer links are all present", async ({ page }) => {
-    await page.goto("/");
-    const footer = page.getByRole("contentinfo");
-
-    await expect(footer.getByRole("link", { name: "Pricing" })).toBeVisible();
-    await expect(footer.getByRole("link", { name: "Sign In" })).toBeVisible();
-    await expect(footer.getByRole("link", { name: "Privacy" })).toBeVisible();
-    await expect(footer.getByRole("link", { name: "Terms" })).toBeVisible();
-  });
-
-  test("10. footer Privacy link navigates to /privacy", async ({ page }) => {
+  test("7. footer Privacy link navigates to /privacy", async ({ page }) => {
     await page.goto("/");
     await page.getByRole("contentinfo").getByRole("link", { name: "Privacy" }).click();
     await expect(page).toHaveURL("/privacy");
   });
 
-  test("11. features section is present with key feature cards", async ({ page }) => {
+  test("8. footer tagline is present", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByRole("heading", { name: "Real-Time Sync" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Team Collaboration" })).toBeVisible();
-    await expect(page.getByRole("heading", { name: "Offline First" })).toBeVisible();
+    await expect(page.getByText("Made carefully, in a quiet room.")).toBeVisible();
   });
 
-  test("12. waitlist section shows email form for iOS app", async ({ page }) => {
+  test("9. OG image meta tag points to /og-image.png", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByText("iOS app launching soon")).toBeVisible();
-    await expect(page.getByPlaceholder("your@email.com")).toBeVisible();
-    await expect(page.getByRole("button", { name: "Join the waitlist" })).toBeVisible();
+    const ogImage = page.locator('meta[property="og:image"]');
+    await expect(ogImage).toHaveAttribute("content", /\/og-image\.png/);
+    const twitterImage = page.locator('meta[name="twitter:image"]');
+    await expect(twitterImage).toHaveAttribute("content", /\/og-image\.png/);
   });
 
-  test("13. pricing summary section shows Free, Pro, Team plans", async ({ page }) => {
+  test("10. no fabricated user-count stats are visible", async ({ page }) => {
     await page.goto("/");
-    // Pricing summary is inline on the landing page
-    await expect(page.getByText("5 lists").first()).toBeVisible();
-    await expect(page.getByText("Unlimited lists").first()).toBeVisible();
-    await expect(page.getByRole("link", { name: /See full pricing details/i })).toBeVisible();
+    const pageContent = await page.content();
+    expect(pageContent).not.toMatch(
+      /\b\d[\d,]+\+?\s*(users|customers|downloads|reviews|ratings)\b/i,
+    );
   });
 
-  test("14. social proof strip shows accurate feature claims (no fake numbers)", async ({ page }) => {
+  test("11. no 'loved by' testimonials section", async ({ page }) => {
     await page.goto("/");
-    // These are factual capability claims, not user stats — scoped to the social proof strip
-    await expect(page.getByText("Free forever plan").first()).toBeVisible();
-    await expect(page.getByText("No credit card required").first()).toBeVisible();
-    await expect(page.getByText("Works offline").first()).toBeVisible();
+    await expect(page.getByRole("heading", { name: /testimonial/i })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: /loved by/i })).not.toBeVisible();
   });
 });

--- a/e2e/lists.spec.ts
+++ b/e2e/lists.spec.ts
@@ -17,11 +17,11 @@ test.describe("List management", () => {
     await page.goto("/app");
 
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });
-    await expect(page.getByText("No lists yet!")).toBeVisible();
+    await expect(page.getByText("Nothing here yet.")).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Create Your First List" }),
+      page.getByRole("button", { name: "Make your first list" }),
     ).toBeVisible();
   });
 
@@ -30,7 +30,7 @@ test.describe("List management", () => {
     await seedAuthSession(page);
     await page.goto("/app");
 
-    await page.getByRole("button", { name: "➕ New list" }).click({ timeout: 10000 });
+    await page.getByRole("button", { name: "Create new list" }).click({ timeout: 10000 });
 
     // Template picker opens first
     await expect(
@@ -50,7 +50,7 @@ test.describe("List management", () => {
     await seedAuthSession(page);
     await page.goto("/app");
 
-    await page.getByRole("button", { name: "➕ New list" }).click({ timeout: 10000 });
+    await page.getByRole("button", { name: "Create new list" }).click({ timeout: 10000 });
     await expect(
       page.getByRole("heading", { name: "Choose a Template" }),
     ).toBeVisible({ timeout: 5000 });
@@ -71,7 +71,7 @@ test.describe("List management", () => {
     await seedAuthSession(page);
     await page.goto("/app");
 
-    await page.getByRole("button", { name: "➕ New list" }).click({ timeout: 10000 });
+    await page.getByRole("button", { name: "Create new list" }).click({ timeout: 10000 });
     await expect(
       page.getByRole("heading", { name: "Choose a Template" }),
     ).toBeVisible({ timeout: 5000 });
@@ -89,7 +89,7 @@ test.describe("List management", () => {
     await seedAuthSession(page);
     await page.goto("/app");
 
-    await page.getByRole("button", { name: "➕ New list" }).click({ timeout: 10000 });
+    await page.getByRole("button", { name: "Create new list" }).click({ timeout: 10000 });
     await expect(
       page.getByRole("heading", { name: "Choose a Template" }),
     ).toBeVisible({ timeout: 5000 });

--- a/e2e/offline.spec.ts
+++ b/e2e/offline.spec.ts
@@ -22,7 +22,7 @@ async function gotoAppOnline(page: import("@playwright/test").Page) {
   await seedAuthSession(page);
   await page.goto("/app");
   await expect(
-    page.getByRole("heading", { name: "Your Lists" }),
+    page.getByRole("heading", { name: /Your lists|Welcome in/i }),
   ).toBeVisible({ timeout: 10000 });
 }
 
@@ -71,7 +71,7 @@ test.describe("Offline indicator", () => {
 
     // The home page content should still be visible despite being offline
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 5000 });
   });
 });

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -2,7 +2,7 @@
  * Onboarding flow tests (POO-45)
  *
  * Tests the 2-step new-user onboarding:
- *   Step 1 — auto-create "Getting Started 💩" demo list on first login.
+ *   Step 1 — auto-create "Getting Started" demo list on first login.
  *   Step 2 — InviteNudge banner shown after user creates their first real list.
  *
  * All tests use:
@@ -78,7 +78,7 @@ async function mockConvexWebSocket(
                       ? Array.from({ length: existingListCount }, (_, i) => ({
                           _id: `lists:mocklist${i}`,
                           _creationTime: Date.now() - (existingListCount - i) * 3600_000,
-                          name: i === 0 ? "Getting Started 💩" : `Test List ${i}`,
+                          name: i === 0 ? "Getting Started" : `Test List ${i}`,
                           ownerDid: "did:webvh:e2e.poo.app:users:e2e-suborg-001",
                           assetDid: `did:example:asset${i}`,
                           createdAt: Date.now() - (existingListCount - i) * 3600_000,
@@ -185,12 +185,12 @@ test.describe("Onboarding: 2-step new user flow (POO-45)", () => {
 
     // Wait for home page to settle
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });
 
     // The old 4-step flow modal should NOT appear — it's suppressed by the 2-step path
     await expect(
-      page.getByRole("heading", { name: "Welcome to Poo App" }),
+      page.getByRole("heading", { name: "Welcome to boop." }),
     ).not.toBeVisible();
   });
 
@@ -203,7 +203,7 @@ test.describe("Onboarding: 2-step new user flow (POO-45)", () => {
 
     // Wait for the home page to load and the demo creation effect to run
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });
 
     // Give the async demo creation a moment to fire
@@ -225,7 +225,7 @@ test.describe("Onboarding: 2-step new user flow (POO-45)", () => {
     await page.goto("/app");
 
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });
 
     // Give the effect time to run
@@ -250,7 +250,7 @@ test.describe("Onboarding: 2-step new user flow (POO-45)", () => {
     await page.goto("/app");
 
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });
 
     // Open template picker (pill chip "New list" button — first match; FAB is second)
@@ -285,7 +285,7 @@ test.describe("Onboarding: 2-step new user flow (POO-45)", () => {
     await page.goto("/app");
 
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });
 
     // Open template picker and create a blank list
@@ -330,7 +330,7 @@ test.describe("Onboarding: 2-step new user flow (POO-45)", () => {
     await page.goto("/app");
 
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });
 
     // Create a list

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -73,7 +73,7 @@ test.describe("Profile page", () => {
 
     await expect(page).toHaveURL("/app", { timeout: 10000 });
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });
   });
 

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -22,7 +22,7 @@ async function openSettings(page: import("@playwright/test").Page) {
   await page.goto("/app");
 
   await expect(
-    page.getByRole("heading", { name: "Your Lists" }),
+    page.getByRole("heading", { name: /Your lists|Welcome in/i }),
   ).toBeVisible({ timeout: 10000 });
 
   await page.getByRole("button", { name: "Settings" }).click();

--- a/e2e/smoke-upgrade-journey.spec.ts
+++ b/e2e/smoke-upgrade-journey.spec.ts
@@ -71,8 +71,6 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
 
   test("1. landing page loads with branding", async ({ page }) => {
     await page.goto("/");
-    // Landing page shows the boop wordmark in the nav
-    await expect(page.getByRole("navigation").getByText("boop").first()).toBeVisible();
     // Hero heading
     await expect(page.getByRole("heading", { level: 1, name: /boop\./ })).toBeVisible();
   });

--- a/e2e/smoke-upgrade-journey.spec.ts
+++ b/e2e/smoke-upgrade-journey.spec.ts
@@ -71,16 +71,14 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
 
   test("1. landing page loads with branding", async ({ page }) => {
     await page.goto("/");
-    // Landing page shows product name and tagline
-    await expect(page.getByText("Poo App").first()).toBeVisible();
-    // Pricing link is present in the nav
-    await expect(page.getByRole("navigation").getByRole("link", { name: "Pricing" })).toBeVisible();
+    // Landing page shows the boop wordmark in the nav
+    await expect(page.getByRole("navigation").getByText("boop").first()).toBeVisible();
+    // Hero heading
+    await expect(page.getByRole("heading", { level: 1, name: /boop\./ })).toBeVisible();
   });
 
-  test("2. pricing link in nav navigates to pricing page", async ({ page }) => {
-    await page.goto("/");
-    await page.getByRole("navigation").getByRole("link", { name: "Pricing" }).click();
-    await expect(page).toHaveURL("/pricing");
+  test("2. direct navigation to /pricing shows pricing headline", async ({ page }) => {
+    await page.goto("/pricing");
     await expect(
       page.getByRole("heading", { name: "Simple, honest pricing" }),
     ).toBeVisible();
@@ -112,6 +110,11 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
   test("5. pricing page: unauthenticated upgrade redirects to login", async ({
     page,
   }) => {
+    // Dismiss the cookie-consent banner, which otherwise intercepts pointer events
+    // in the bottom area of the pricing page.
+    await page.addInitScript(() => {
+      localStorage.setItem("poo-cookie-consent", "accepted");
+    });
     await page.goto("/pricing");
     await page.getByRole("button", { name: "Upgrade to Pro" }).click();
     // Unauthenticated user is redirected to login
@@ -124,9 +127,6 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
 
   test("6. sign-up: email entry shows send-code button", async ({ page }) => {
     await page.goto("/login");
-    await expect(
-      page.getByRole("heading", { name: "Welcome to Poo App" }),
-    ).toBeVisible();
     await expect(
       page.getByPlaceholder("you@example.com"),
     ).toBeVisible();
@@ -142,7 +142,7 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
     await page.getByRole("button", { name: /Send Code/i }).click();
     // After initiating OTP, the verification step is shown
     await expect(
-      page.getByText(/Enter the code we sent to/),
+      page.getByText(/We sent a code to/),
     ).toBeVisible({ timeout: 5000 });
     await expect(
       page.getByLabel("Digit 1"),
@@ -177,11 +177,11 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
     await page.goto("/app");
 
     await expect(
-      page.getByRole("heading", { name: "Your Lists" }),
+      page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });
     // FAB / new list button is visible
     await expect(
-      page.getByRole("button", { name: "➕ New list" }),
+      page.getByRole("button", { name: "Create new list" }),
     ).toBeVisible({ timeout: 10000 });
   });
 
@@ -192,7 +192,7 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
     await seedAuthSession(page);
     await page.goto("/app");
 
-    await page.getByRole("button", { name: "➕ New list" }).click({ timeout: 10000 });
+    await page.getByRole("button", { name: "Create new list" }).click({ timeout: 10000 });
     // Template picker opens first — select "Blank List" to get the create modal
     await expect(page.getByRole("heading", { name: "Choose a Template" })).toBeVisible({ timeout: 5000 });
     await page.getByRole("button", { name: "Blank List" }).click();
@@ -214,13 +214,13 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
     await page.goto("/app");
 
     // Wait for home page to finish loading
-    await page.getByRole("button", { name: "➕ New list" }).waitFor({
+    await page.getByRole("button", { name: "Create new list" }).waitFor({
       state: "visible",
       timeout: 10000,
     });
 
     // Open create list modal via template picker
-    await page.getByRole("button", { name: "➕ New list" }).click();
+    await page.getByRole("button", { name: "Create new list" }).click();
     await expect(page.getByRole("heading", { name: "Choose a Template" })).toBeVisible({ timeout: 5000 });
     await page.getByRole("button", { name: "Blank List" }).click();
     await page.getByLabel("List name").waitFor({ state: "visible", timeout: 5000 });
@@ -246,11 +246,11 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
     await seedAuthSession(page);
     await page.goto("/app");
 
-    await page.getByRole("button", { name: "➕ New list" }).waitFor({
+    await page.getByRole("button", { name: "Create new list" }).waitFor({
       state: "visible",
       timeout: 10000,
     });
-    await page.getByRole("button", { name: "➕ New list" }).click();
+    await page.getByRole("button", { name: "Create new list" }).click();
     await expect(page.getByRole("heading", { name: "Choose a Template" })).toBeVisible({ timeout: 5000 });
     await page.getByRole("button", { name: "Blank List" }).click();
     await page.getByLabel("List name").waitFor({ state: "visible", timeout: 5000 });

--- a/e2e/terms.spec.ts
+++ b/e2e/terms.spec.ts
@@ -61,23 +61,11 @@ test.describe("Terms of Service page", () => {
   test("6. back link navigates to landing page", async ({ page }) => {
     await page.goto("/terms");
 
-    const backLink = page.getByRole("link", { name: /Back to Poo App/i });
+    const backLink = page.getByRole("link", { name: /Back to boop/i });
     await expect(backLink).toBeVisible();
     await backLink.click();
 
     // Should be on the landing page
     await expect(page).toHaveURL("/");
-  });
-
-  test("7. footer Terms link on landing page navigates to /terms", async ({ page }) => {
-    await page.goto("/");
-
-    // Footer has a Terms link
-    const termsLink = page.getByRole("contentinfo").getByRole("link", { name: "Terms" });
-    await expect(termsLink).toBeVisible();
-    await termsLink.click();
-
-    await expect(page).toHaveURL("/terms");
-    await expect(page.getByRole("heading", { name: "Terms of Service" })).toBeVisible();
   });
 });

--- a/index.html
+++ b/index.html
@@ -3,43 +3,43 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="description" content="Poo App - Organize your life while you poop. The world's most productive todo app." />
-    
+    <meta name="description" content="boop — a calm little place for the things you need to do, alone or with a few people you trust." />
+
     <!-- Theme and PWA -->
-    <meta name="theme-color" content="#78350F" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#1F2937" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#fafaf7" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0c0b10" media="(prefers-color-scheme: dark)" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="Poo App" />
+    <meta name="apple-mobile-web-app-title" content="boop" />
     <meta name="mobile-web-app-capable" content="yes" />
-    
+
     <!-- Manifest -->
     <link rel="manifest" href="/manifest.json" />
-    
+
     <!-- Favicon -->
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💩</text></svg>" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><circle cx=%2250%22 cy=%2250%22 r=%2240%22 fill=%22%236b3cff%22/></svg>" />
     <link rel="apple-touch-icon" href="/icons/icon-192.png" />
-    
+
     <!-- Preconnect to important origins -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    
+
     <!-- Social sharing -->
-    <meta property="og:title" content="Poo App" />
-    <meta property="og:description" content="Organize your life while you poop. The world's most productive todo app." />
+    <meta property="og:title" content="boop" />
+    <meta property="og:description" content="A calm little place for the things you need to do. No feeds, no nags, no notifications asking how you feel." />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="/og-image.png" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Poo App" />
-    <meta name="twitter:description" content="Organize your life while you poop 💩" />
+    <meta name="twitter:title" content="boop" />
+    <meta name="twitter:description" content="A calm little place for the things you need to do." />
     <meta name="twitter:image" content="/og-image.png" />
 
-    <title>💩 Poo App - Organize Your Life</title>
+    <title>boop</title>
     
     <!-- Initialize dark mode before render to prevent flash -->
     <script>
       (function() {
-        const stored = localStorage.getItem('pooapp:darkMode');
+        const stored = localStorage.getItem('pooapp:darkMode') || localStorage.getItem('boop:darkMode');
         const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
         if (stored === 'true' || (stored === null && prefersDark)) {
           document.documentElement.classList.add('dark');

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,6 +23,10 @@ export default defineConfig({
     reuseExistingServer: !process.env.CI,
     env: {
       VITE_E2E_MOCK_ORIGINALS: "true",
+      // Stub Stripe price IDs so the Upgrade buttons are not disabled during tests.
+      VITE_STRIPE_PRO_MONTHLY_PRICE_ID: "price_e2e_pro_monthly",
+      VITE_STRIPE_PRO_YEARLY_PRICE_ID: "price_e2e_pro_yearly",
+      VITE_STRIPE_TEAM_PRICE_ID: "price_e2e_team",
     },
   },
 });

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,11 +1,11 @@
 {
-  "name": "Poo App",
-  "short_name": "Poo",
-  "description": "Organize your life while you poop. The world's most productive todo app.",
+  "name": "boop",
+  "short_name": "boop",
+  "description": "A calm little place for the things you need to do.",
   "start_url": "/",
   "display": "standalone",
-  "background_color": "#FFFBEB",
-  "theme_color": "#78350F",
+  "background_color": "#fafaf7",
+  "theme_color": "#6b3cff",
   "orientation": "portrait-primary",
   "icons": [
     {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,10 +58,11 @@ function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
           <Link
             to="/app"
             onClick={() => haptic('light')}
-            className="flex items-center gap-2 text-xl font-black text-amber-900 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300 transition-colors"
+            className="boop-wordmark text-[20px] leading-none hover:opacity-80 transition-opacity"
+            aria-label="boop — home"
           >
-            <span className="text-2xl">💩</span>
-            <span>Poo App</span>
+            <span className="boop-dot" aria-hidden="true" />
+            <span>boop</span>
           </Link>
           
           <div className="flex items-center gap-2">
@@ -138,7 +139,16 @@ function PageLoadingFallback() {
   return (
     <div className="min-h-screen bg-stone-50 dark:bg-gray-950 flex items-center justify-center">
       <div className="text-center">
-        <div className="text-6xl mb-4">💩</div>
+        <div
+          className="mx-auto mb-5 rounded-full"
+          style={{
+            width: 56,
+            height: 56,
+            background: 'var(--boop-accent)',
+            animation: 'pulse-ring 2s ease-in-out infinite',
+          }}
+          aria-hidden="true"
+        />
         <div className="animate-pulse space-y-3">
           <div className="h-4 bg-stone-200 dark:bg-gray-700 rounded w-48 mx-auto"></div>
           <div className="h-3 bg-stone-200 dark:bg-gray-700 rounded w-32 mx-auto"></div>

--- a/src/components/AddItemInput.tsx
+++ b/src/components/AddItemInput.tsx
@@ -82,7 +82,7 @@ export const AddItemInput = forwardRef<HTMLInputElement, AddItemInputProps>(func
       <button
         type="submit"
         disabled={isAdding || !name.trim()}
-        className="px-6 py-3.5 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 hover:shadow-xl hover:shadow-amber-500/30 focus:outline-none focus:ring-4 focus:ring-amber-500/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all active:scale-95"
+        className="px-6 py-3.5 bg-amber-500 hover:bg-amber-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 hover:shadow-xl hover:shadow-amber-500/30 focus:outline-none focus:ring-4 focus:ring-amber-500/30 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all active:scale-95"
       >
         {isAdding ? (
           <span className="flex items-center gap-2">

--- a/src/components/AppLockGuard.tsx
+++ b/src/components/AppLockGuard.tsx
@@ -50,7 +50,7 @@ export function AppLockGuard({ children }: AppLockGuardProps) {
 
   // Show lock screen
   return (
-    <div className="fixed inset-0 bg-gradient-to-br from-amber-100 to-orange-100 dark:from-gray-900 dark:to-gray-800 flex items-center justify-center z-50">
+    <div className="fixed inset-0 bg-amber-100 dark:bg-gray-900 flex items-center justify-center z-50">
       <div className="text-center px-6">
         <div className="mb-8">
           <span className="text-8xl">🔒</span>

--- a/src/components/AppLockGuard.tsx
+++ b/src/components/AppLockGuard.tsx
@@ -32,7 +32,7 @@ export function AppLockGuard({ children }: AppLockGuardProps) {
   const authenticate = async () => {
     setIsAuthenticating(true);
     try {
-      const success = await biometrics.authenticate('Unlock Poo App');
+      const success = await biometrics.authenticate('Unlock boop');
       if (success) {
         setIsLocked(false);
       }
@@ -55,8 +55,16 @@ export function AppLockGuard({ children }: AppLockGuardProps) {
         <div className="mb-8">
           <span className="text-8xl">🔒</span>
         </div>
-        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-3">
-          Poo App is Locked
+        <h1
+          className="text-gray-900 dark:text-gray-100 mb-3"
+          style={{
+            fontFamily: 'Nunito, system-ui, sans-serif',
+            fontWeight: 800,
+            fontSize: 30,
+            letterSpacing: -1,
+          }}
+        >
+          boop is locked
         </h1>
         <p className="text-gray-600 dark:text-gray-400 mb-8">
           Use Face ID or fingerprint to unlock

--- a/src/components/ChangeCategoryDialog.tsx
+++ b/src/components/ChangeCategoryDialog.tsx
@@ -73,7 +73,7 @@ export function ChangeCategoryDialog({
             type="button"
             onClick={handleSave}
             disabled={saving}
-            className="px-4 py-2 text-sm text-white bg-gradient-to-r from-amber-600 to-orange-500 rounded-lg hover:from-amber-500 hover:to-orange-400 disabled:opacity-50 transition-all"
+            className="px-4 py-2 text-sm text-white bg-amber-600 rounded-lg hover:bg-amber-500 disabled:opacity-50 transition-all"
           >
             {saving ? "Saving..." : "Save"}
           </button>

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -47,7 +47,7 @@ export function ConfirmDialog({
   const confirmButtonClasses =
     confirmVariant === "danger"
       ? "bg-red-600 text-white hover:bg-red-700"
-      : "bg-gradient-to-r from-amber-600 to-orange-500 text-white hover:from-amber-500 hover:to-orange-400 transition-all";
+      : "bg-amber-600 text-white hover:bg-amber-500 transition-all";
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">

--- a/src/components/CookieConsent.tsx
+++ b/src/components/CookieConsent.tsx
@@ -72,7 +72,7 @@ export function CookieConsent() {
               Cookies & Analytics
             </p>
             <p className="text-sm text-gray-600 dark:text-gray-400">
-              We use PostHog to understand how you use Poo App so we can make it better.
+              We use PostHog to understand how you use boop so we can make it better.
               No data is sold or shared with third parties.{' '}
               <a
                 href="/privacy"

--- a/src/components/CreateListModal.tsx
+++ b/src/components/CreateListModal.tsx
@@ -139,7 +139,7 @@ export function CreateListModal({ onClose, onListCreated }: CreateListModalProps
       <button
         type="button"
         onClick={() => { haptic('medium'); handleShareList(); }}
-        className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 transition-all"
+        className="flex-1 px-4 py-3 bg-amber-500 hover:bg-amber-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 transition-all"
       >
         Share list
       </button>
@@ -161,7 +161,7 @@ export function CreateListModal({ onClose, onListCreated }: CreateListModalProps
         type="submit"
         form="create-list-form"
         disabled={isCreating || !name.trim()}
-        className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
+        className="flex-1 px-4 py-3 bg-amber-500 hover:bg-amber-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
       >
         {isCreating ? (
           <span className="flex items-center justify-center gap-2">

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -48,7 +48,7 @@ export class ErrorBoundary extends Component<Props, State> {
             <div className="flex gap-2 justify-center">
               <button
                 onClick={() => window.location.reload()}
-                className="bg-gradient-to-r from-amber-500 to-orange-500 text-white px-4 py-2 rounded hover:from-amber-400 hover:to-orange-400 transition-all"
+                className="bg-amber-500 text-white px-4 py-2 rounded hover:bg-amber-400 transition-all"
               >
                 Reload Page
               </button>

--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -1,13 +1,15 @@
 /**
- * Card displaying a list summary — modern minimal design.
+ * Card displaying a list summary — Boop design.
  *
- * Clean card with warm amber accents, subtle shadows, rounded corners.
- * Optimized for mobile with good touch targets and whitespace.
+ * Mono category line up top, big Nunito name, progress bar with
+ * done count at the bottom. Matches the Boop prototype BoopListCard.
  */
 
 import { memo } from "react";
+import { useQuery } from "convex/react";
 import { Link } from "react-router-dom";
 import type { Doc } from "../../convex/_generated/dataModel";
+import { api } from "../../convex/_generated/api";
 import { useSettings } from "../hooks/useSettings";
 
 interface ListCardProps {
@@ -18,67 +20,82 @@ interface ListCardProps {
 
 function truncateDid(did: string): string {
   if (did.length <= 24) return did;
-  return `${did.slice(0, 12)}...${did.slice(-8)}`;
-}
-
-function getListEmoji(name: string): string {
-  const emojis = ['📋', '📝', '✅', '📌', '🎯', '📊', '🗂️', '📒', '📓', '🗒️'];
-  const index = name.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0) % emojis.length;
-  return emojis[index];
+  return `${did.slice(0, 12)}…${did.slice(-6)}`;
 }
 
 function formatRelativeTime(timestamp: number): string {
   const seconds = Math.floor((Date.now() - timestamp) / 1000);
-  
-  if (seconds < 60) return 'Just now';
+  if (seconds < 60) return 'just now';
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
   if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
   if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
-  
   return new Date(timestamp).toLocaleDateString();
 }
 
 export const ListCard = memo(function ListCard({ list, currentUserDid, showOwner }: ListCardProps) {
   const { haptic } = useSettings();
   const isOwner = list.ownerDid === currentUserDid;
-  const emoji = getListEmoji(list.name);
+
+  // Pull item counts so the card can show progress. `skip` when we don't need it.
+  const items = useQuery(api.items.getListItems, { listId: list._id });
+  const total = items?.length ?? 0;
+  const done = items?.filter(i => i.checked).length ?? 0;
+  const pct = total ? Math.round((done / total) * 100) : 0;
+
+  const tagParts: string[] = [];
+  if (showOwner && !isOwner) tagParts.push(truncateDid(list.ownerDid));
+  else if (!isOwner) tagParts.push('shared');
+  else tagParts.push('personal');
+  tagParts.push(formatRelativeTime(list.createdAt));
 
   return (
     <Link
       to={`/list/${list._id}`}
       onClick={() => haptic('light')}
-      className="group block bg-white dark:bg-stone-800/70 rounded-2xl shadow-sm shadow-stone-200/60 dark:shadow-none hover:shadow-md hover:shadow-stone-200/80 dark:hover:shadow-none transition-all duration-200 p-5 border border-stone-100 dark:border-stone-700/40 hover:border-amber-300/50 dark:hover:border-amber-700/40 active:scale-[0.98]"
+      className="group block relative overflow-hidden bg-white dark:bg-stone-800/70 rounded-[18px] p-[18px] border border-stone-200/70 dark:border-stone-700/50 hover:border-amber-300/60 dark:hover:border-amber-700/50 hover:-translate-y-[1px] transition-all duration-150 active:scale-[0.99]"
       aria-label={`Open list: ${list.name}`}
     >
-      <div className="flex items-center gap-4">
-        {/* Emoji badge */}
-        <div className="flex-shrink-0 w-12 h-12 bg-amber-50 dark:bg-amber-900/30 rounded-xl flex items-center justify-center text-2xl group-hover:scale-105 transition-transform duration-200">
-          {emoji}
-        </div>
-
-        <div className="flex-1 min-w-0">
-          {/* List name */}
-          <div className="flex items-center gap-2 mb-0.5">
-            <h3 className="text-base font-semibold text-stone-900 dark:text-stone-50 truncate group-hover:text-amber-700 dark:group-hover:text-amber-400 transition-colors">
-              {list.name}
-            </h3>
-            {!isOwner && (
-              <span className="flex-shrink-0 px-2 py-0.5 rounded-md text-[11px] font-semibold bg-amber-100/80 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400">
-                Shared
-              </span>
-            )}
+      {/* Header: tag line + (placeholder for avatar stack) */}
+      <div className="relative flex justify-between items-start mb-4">
+        <div className="min-w-0">
+          <div
+            className="flex items-center gap-1.5 mb-1 text-[11px] text-stone-500 dark:text-stone-400 lowercase"
+            style={{ fontFamily: 'Geist Mono, ui-monospace, monospace' }}
+          >
+            <span className="truncate">{tagParts.join(' · ')}</span>
           </div>
-
-          {/* Meta line */}
-          <p className="text-[13px] text-stone-400 dark:text-stone-500">
-            {showOwner && !isOwner ? truncateDid(list.ownerDid) : formatRelativeTime(list.createdAt)}
-          </p>
+          <h3
+            className="text-stone-900 dark:text-stone-50 truncate"
+            style={{
+              fontFamily: 'Nunito, system-ui, sans-serif',
+              fontWeight: 700,
+              fontSize: 20,
+              letterSpacing: -0.4,
+              lineHeight: 1.15,
+            }}
+          >
+            {list.name}
+          </h3>
         </div>
+      </div>
 
-        {/* Chevron */}
-        <svg className="w-5 h-5 flex-shrink-0 text-stone-300 dark:text-stone-600 group-hover:text-amber-400 group-hover:translate-x-0.5 transition-all duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-        </svg>
+      {/* Progress bar + done count */}
+      <div className="relative flex items-center gap-2.5">
+        <div className="flex-1 h-[4px] rounded-full overflow-hidden bg-stone-200/70 dark:bg-stone-700/60">
+          <div
+            className="h-full rounded-full transition-[width] duration-300"
+            style={{
+              width: `${pct}%`,
+              background: 'var(--boop-accent)',
+            }}
+          />
+        </div>
+        <span
+          className="text-[11px] text-stone-500 dark:text-stone-400 tabular-nums"
+          style={{ fontFamily: 'Geist Mono, ui-monospace, monospace' }}
+        >
+          {items === undefined ? '…' : `${done}/${total}`}
+        </span>
       </div>
     </Link>
   );

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -235,10 +235,10 @@ export const ListItem = memo(function ListItem({
           aria-checked={isSelected}
           aria-label={`Select ${item.name}`}
         >
-          <div className={`w-6 h-6 rounded-lg flex items-center justify-center transition-all ${
+          <div className={`w-6 h-6 rounded-full flex items-center justify-center transition-all ${
             isSelected
-              ? "bg-amber-500 text-white"
-              : "bg-gray-200 dark:bg-gray-600"
+              ? "bg-[#6b3cff] text-white"
+              : "bg-stone-200 dark:bg-stone-600"
           }`}>
             {isSelected && (
               <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
@@ -279,45 +279,49 @@ export const ListItem = memo(function ListItem({
             handleToggleCheck();
           }}
           disabled={isUpdating}
-          className={`flex-shrink-0 w-8 h-8 rounded-md flex items-center justify-center transition-all active:scale-90 disabled:opacity-50 -ml-2`}
+          className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center transition-all active:scale-90 disabled:opacity-50 -ml-2`}
           aria-label={item.checked ? `Uncheck ${item.name}` : `Check ${item.name}`}
         >
-          <div className={`w-5 h-5 rounded-md flex items-center justify-center transition-all ${
-            item.checked
-              ? "bg-gradient-to-br from-green-500 to-emerald-600 text-white shadow-sm shadow-green-500/30"
-              : "bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 border border-gray-200 dark:border-gray-600"
-          }`}>
-            {item.checked ? (
-              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+          <div
+            className={`w-5 h-5 rounded-full flex items-center justify-center transition-all ${
+              item.checked
+                ? "bg-[#6b3cff] text-white shadow-sm shadow-[#6b3cff]/30"
+                : "bg-transparent border-[1.6px] border-stone-300 dark:border-stone-500 hover:border-[#6b3cff] dark:hover:border-[#9b74ff]"
+            }`}
+          >
+            {item.checked && (
+              <svg className="w-3 h-3" viewBox="0 0 12 12" fill="none" aria-hidden="true">
                 <path
-                  fillRule="evenodd"
-                  d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                  clipRule="evenodd"
+                  d="M2.5 6.5l2.5 2.5 5-6"
+                  stroke="currentColor"
+                  strokeWidth="1.8"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
                 />
               </svg>
-            ) : (
-              <div className="w-2 h-2" aria-hidden="true" />
             )}
           </div>
         </button>
       ) : (
         // Read-only checkbox display for viewers
         <div
-          className={`flex-shrink-0 w-5 h-5 rounded-md flex items-center justify-center ${
-            item.checked 
-              ? "bg-gradient-to-br from-green-500 to-emerald-600 text-white" 
-              : "bg-gray-100 dark:bg-gray-700"
+          className={`flex-shrink-0 w-5 h-5 rounded-full flex items-center justify-center ${
+            item.checked
+              ? "bg-[#6b3cff] text-white"
+              : "border-[1.6px] border-stone-300 dark:border-stone-500"
           }`}
           role="checkbox"
           aria-checked={item.checked}
           aria-label={`${item.name} is ${item.checked ? 'checked' : 'unchecked'}`}
         >
           {item.checked && (
-            <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+            <svg className="w-3 h-3" viewBox="0 0 12 12" fill="none" aria-hidden="true">
               <path
-                fillRule="evenodd"
-                d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                clipRule="evenodd"
+                d="M2.5 6.5l2.5 2.5 5-6"
+                stroke="currentColor"
+                strokeWidth="1.8"
+                strokeLinecap="round"
+                strokeLinejoin="round"
               />
             </svg>
           )}

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -180,7 +180,7 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
   };
 
   return createPortal(
-    <div className="fixed inset-0 z-[200] flex flex-col bg-gradient-to-b from-amber-50 via-orange-50 to-amber-100 safe-area-inset-top safe-area-inset-bottom">
+    <div className="fixed inset-0 z-[200] flex flex-col bg-amber-50 safe-area-inset-top safe-area-inset-bottom">
       {/* Top bar: progress + skip */}
       <div className="flex items-center justify-between px-5 pt-4 pb-2">
         {/* Progress dots */}
@@ -287,7 +287,7 @@ function WelcomeStep({ onNext }: { onNext: () => void }) {
       </p>
       <button
         onClick={onNext}
-        className="w-full py-4 bg-gradient-to-r from-amber-600 to-orange-500 text-white rounded-2xl font-bold text-lg shadow-xl shadow-amber-500/30 hover:from-amber-500 hover:to-orange-400 active:from-amber-700 active:to-orange-600 transition-all"
+        className="w-full py-4 bg-amber-600 text-white rounded-2xl font-bold text-lg shadow-xl shadow-amber-500/30 hover:bg-amber-500 active:bg-amber-700 transition-all"
       >
         Let's go 🚀
       </button>
@@ -336,7 +336,7 @@ function CreateListStep({
         <button
           type="submit"
           disabled={!value.trim() || isCreating}
-          className="w-full py-4 bg-gradient-to-r from-amber-600 to-orange-500 text-white rounded-2xl font-bold text-base shadow-lg shadow-amber-500/25 disabled:opacity-40 disabled:cursor-not-allowed hover:from-amber-500 hover:to-orange-400 transition-all"
+          className="w-full py-4 bg-amber-600 text-white rounded-2xl font-bold text-base shadow-lg shadow-amber-500/25 disabled:opacity-40 disabled:cursor-not-allowed hover:bg-amber-500 transition-all"
         >
           {isCreating ? "Creating..." : "Create List ✨"}
         </button>
@@ -414,7 +414,7 @@ function AddItemsStep({
 
       <button
         onClick={onNext}
-        className="w-full py-4 bg-gradient-to-r from-amber-600 to-orange-500 text-white rounded-2xl font-bold text-base shadow-lg shadow-amber-500/25 hover:from-amber-500 hover:to-orange-400 transition-all"
+        className="w-full py-4 bg-amber-600 text-white rounded-2xl font-bold text-base shadow-lg shadow-amber-500/25 hover:bg-amber-500 transition-all"
       >
         {addedItems.length === 0 ? "Skip this step →" : "Next →"}
       </button>
@@ -480,7 +480,7 @@ export function InviteNudge({
             <div className="flex gap-2">
               <button
                 onClick={handleInvite}
-                className="flex-1 py-2.5 bg-gradient-to-r from-amber-500 to-orange-500 text-white rounded-xl font-semibold text-sm shadow-lg shadow-amber-500/25 hover:from-amber-400 hover:to-orange-400 transition-all"
+                className="flex-1 py-2.5 bg-amber-500 text-white rounded-xl font-semibold text-sm shadow-lg shadow-amber-500/25 hover:bg-amber-400 transition-all"
               >
                 Invite someone →
               </button>
@@ -573,7 +573,7 @@ function ShareStep({
 
           <button
             onClick={onFinish}
-            className="w-full py-4 bg-gradient-to-r from-amber-600 to-orange-500 text-white rounded-2xl font-bold text-base shadow-lg shadow-amber-500/25 hover:from-amber-500 hover:to-orange-400 transition-all"
+            className="w-full py-4 bg-amber-600 text-white rounded-2xl font-bold text-base shadow-lg shadow-amber-500/25 hover:bg-amber-500 transition-all"
           >
             Open my list →
           </button>
@@ -604,7 +604,7 @@ function ShareStep({
           <button
             onClick={onPublish}
             disabled={isPublishing}
-            className="w-full py-4 bg-gradient-to-r from-amber-600 to-orange-500 text-white rounded-2xl font-bold text-base shadow-lg shadow-amber-500/25 disabled:opacity-50 hover:from-amber-500 hover:to-orange-400 transition-all"
+            className="w-full py-4 bg-amber-600 text-white rounded-2xl font-bold text-base shadow-lg shadow-amber-500/25 disabled:opacity-50 hover:bg-amber-500 transition-all"
           >
             {isPublishing ? (
               <span className="flex items-center justify-center gap-2">

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -259,16 +259,29 @@ export function OnboardingFlow({ onComplete }: OnboardingFlowProps) {
 function WelcomeStep({ onNext }: { onNext: () => void }) {
   return (
     <div className="text-center max-w-sm w-full">
-      <div className="text-[100px] leading-none mb-6 animate-bounce-slow">
-        💩
+      <div className="mx-auto mb-8 flex items-center justify-center" style={{ width: 96, height: 96, borderRadius: '50%', background: 'var(--boop-accent-soft)' }}>
+        <div
+          className="rounded-full animate-bounce-slow"
+          style={{ width: 44, height: 44, background: 'var(--boop-accent)' }}
+          aria-hidden="true"
+        />
       </div>
-      <h1 className="text-3xl font-black text-amber-900 mb-3 leading-tight">
-        Welcome to Poo App
+      <h1
+        className="text-stone-900 dark:text-stone-50 mb-3"
+        style={{
+          fontFamily: 'Nunito, system-ui, sans-serif',
+          fontWeight: 800,
+          fontSize: 32,
+          letterSpacing: -1,
+          lineHeight: 1.1,
+        }}
+      >
+        Welcome to boop.
       </h1>
-      <p className="text-amber-800/70 text-base mb-2 leading-relaxed">
-        Organize your life while you poop.
+      <p className="text-stone-600 dark:text-stone-300 text-base mb-2 leading-relaxed">
+        A calm place for the things you need to do.
       </p>
-      <p className="text-amber-700/60 text-sm mb-10 leading-relaxed">
+      <p className="text-stone-500 dark:text-stone-400 text-sm mb-10 leading-relaxed">
         Let's get you set up in under 60 seconds. We'll create your first
         list and show you how to share it with someone.
       </p>
@@ -562,7 +575,7 @@ function ShareStep({
             onClick={onFinish}
             className="w-full py-4 bg-gradient-to-r from-amber-600 to-orange-500 text-white rounded-2xl font-bold text-base shadow-lg shadow-amber-500/25 hover:from-amber-500 hover:to-orange-400 transition-all"
           >
-            Open my list 💩
+            Open my list →
           </button>
         </div>
       ) : (

--- a/src/components/ReferralInvite.tsx
+++ b/src/components/ReferralInvite.tsx
@@ -72,8 +72,8 @@ export function ReferralInvite({ userId, compact = false }: ReferralInviteProps)
     if (!referralUrl) return;
     if (navigator.share) {
       await navigator.share({
-        title: "Join me on Poo App",
-        text: "I use Poo App to manage my lists. Sign up with my link and we both get 1 month Pro free!",
+        title: "Join me on boop",
+        text: "I use boop to manage my lists. Sign up with my link and we both get 1 month Pro free!",
         url: referralUrl,
       });
     } else {

--- a/src/components/SaveAsTemplateModal.tsx
+++ b/src/components/SaveAsTemplateModal.tsx
@@ -121,7 +121,7 @@ export function SaveAsTemplateModal({ listId, listName, onClose, onSuccess }: Sa
         type="submit"
         form="save-template-form"
         disabled={isSaving || !name.trim()}
-        className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
+        className="flex-1 px-4 py-3 bg-amber-500 hover:bg-amber-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
       >
         {isSaving ? (
           <span className="flex items-center justify-center gap-2">

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -595,16 +595,16 @@ export function Settings({ onClose }: SettingsProps) {
             About
           </h3>
           
-          <div className="bg-gradient-to-r from-amber-50 to-orange-50 dark:from-gray-700 dark:to-gray-700 rounded-xl p-4">
+          <div className="bg-stone-50 dark:bg-gray-700 rounded-xl p-4 border border-stone-200/70 dark:border-transparent">
             <div className="flex items-center gap-3 mb-3">
-              <span className="text-3xl leading-none">💩</span>
-              <div>
-                <p className="font-bold text-gray-900 dark:text-gray-100">Poo App</p>
-                <p className="text-sm text-gray-500 dark:text-gray-400">Version 1.0.0</p>
+              <div className="boop-wordmark text-[22px] leading-none">
+                <span className="boop-dot" aria-hidden="true" />
+                <span>boop</span>
               </div>
+              <p className="text-sm text-gray-500 dark:text-gray-400 ml-auto">v1.0.0</p>
             </div>
             <p className="text-sm text-gray-600 dark:text-gray-300">
-              Organize your life while you poop. Powered by Originals Protocol.
+              A calm place for the things you need to do. Powered by Originals Protocol.
             </p>
           </div>
         </section>

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -209,7 +209,7 @@ export function ShareModal({ list, onClose }: ShareModalProps) {
             {nativeShareAvailable && (
               <button
                 onClick={handleNativeShare}
-                className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 transition-all"
+                className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-amber-500 hover:bg-amber-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 transition-all"
               >
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z" />
@@ -265,7 +265,7 @@ export function ShareModal({ list, onClose }: ShareModalProps) {
             <button
               onClick={handlePublish}
               disabled={isPublishing}
-              className="w-full px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 transition-all"
+              className="w-full px-4 py-3 bg-amber-500 hover:bg-amber-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 transition-all"
             >
               {isPublishing ? (
                 <span className="flex items-center justify-center gap-2">

--- a/src/components/SharedListResource.tsx
+++ b/src/components/SharedListResource.tsx
@@ -3,7 +3,7 @@
  * Accessed via /{userPath}/resources/list-{listId}
  *
  * - Anyone can view the list
- * - Logged-in Poo App users can save to favourites
+ * - Logged-in boop users can save to favourites
  */
 
 import { useEffect, useState, useCallback, useRef } from "react";
@@ -176,12 +176,12 @@ export function SharedListResource() {
     return (
       <div className="min-h-screen bg-gray-50 dark:bg-gray-950 flex items-center justify-center">
         <div className="text-center p-8">
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">
-            {error === "List not found" ? "💩 List not found" : "💩 Something went wrong"}
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2" style={{ fontFamily: 'Nunito, system-ui, sans-serif', letterSpacing: -0.5 }}>
+            {error === "List not found" ? "List not found" : "Something went wrong"}
           </h1>
           <p className="text-gray-500 dark:text-gray-400 mb-4">{error}</p>
-          <Link to="/" className="text-amber-500 hover:text-amber-600 font-medium">
-            Go to Poo App →
+          <Link to="/" className="text-amber-600 hover:text-amber-500 font-medium">
+            Go to boop →
           </Link>
         </div>
       </div>
@@ -198,9 +198,9 @@ export function SharedListResource() {
         {/* Header */}
         <div className="mb-6">
           <div className="flex items-center justify-between mb-1">
-            <div className="flex items-center gap-2 text-sm text-gray-400 dark:text-gray-500">
-              <span>💩</span>
-              <span>Shared List</span>
+            <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+              <span className="boop-dot" aria-hidden="true" style={{ width: 10, height: 10 }} />
+              <span style={{ fontFamily: 'Geist Mono, ui-monospace, monospace', fontSize: 12 }}>shared list</span>
             </div>
             {/* Favourite button — only for logged-in users */}
             {did && convexListId && (
@@ -356,8 +356,8 @@ export function SharedListResource() {
         <div className="mt-6 pt-6 border-t border-gray-200 dark:border-gray-800">
           <p className="text-xs text-gray-400 dark:text-gray-500 text-center">
             Shared via{" "}
-            <a href="https://trypoo.app" className="text-amber-500 hover:text-amber-600">
-              Poo App
+            <a href="/" className="text-amber-600 hover:text-amber-500">
+              boop
             </a>
             {" "}· Verified with{" "}
             <span className="font-mono">did:webvh</span>

--- a/src/components/StreakBadge.tsx
+++ b/src/components/StreakBadge.tsx
@@ -20,7 +20,7 @@ export const StreakBadge = memo(function StreakBadge({ streak, size = 'md' }: St
 
   if (size === 'sm') {
     return (
-      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-bold bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 border border-orange-200/60 dark:border-orange-800/40">
+      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-bold bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 border border-amber-200/60 dark:border-amber-800/40">
         <span>{emoji}</span>
         <span>{streak}d</span>
       </span>
@@ -28,7 +28,7 @@ export const StreakBadge = memo(function StreakBadge({ streak, size = 'md' }: St
   }
 
   return (
-    <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-bold bg-gradient-to-r from-orange-100 to-amber-100 dark:from-orange-900/30 dark:to-amber-900/30 text-orange-700 dark:text-orange-400 border border-orange-200/60 dark:border-orange-800/40 shadow-sm">
+    <span className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-bold bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 border border-amber-200/60 dark:border-amber-800/40 shadow-sm">
       <span className="text-base">{emoji}</span>
       <span>{streak} day{streak !== 1 ? 's' : ''}</span>
     </span>

--- a/src/components/StreakCelebration.tsx
+++ b/src/components/StreakCelebration.tsx
@@ -39,7 +39,7 @@ export function StreakCelebration({ milestone, onDismiss }: StreakCelebrationPro
       }`}
     >
       {/* Backdrop glow */}
-      <div className={`absolute inset-0 bg-gradient-to-b from-orange-500/10 to-amber-500/10 dark:from-orange-500/20 dark:to-amber-500/20 transition-opacity duration-300 ${
+      <div className={`absolute inset-0 bg-amber-500/10 dark:bg-amber-500/20 transition-opacity duration-300 ${
         isVisible ? 'opacity-100' : 'opacity-0'
       }`} />
 

--- a/src/components/TemplatePickerModal.tsx
+++ b/src/components/TemplatePickerModal.tsx
@@ -161,7 +161,7 @@ export function TemplatePickerModal({ onClose, onCreateBlank }: TemplatePickerMo
           type="button"
           onClick={handleCreateFromBuiltin}
           disabled={isCreating}
-          className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
+          className="flex-1 px-4 py-3 bg-amber-500 hover:bg-amber-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 disabled:cursor-not-allowed disabled:shadow-none transition-all"
         >
           {isCreating ? (
             <span className="flex items-center justify-center gap-2">
@@ -269,7 +269,7 @@ export function TemplatePickerModal({ onClose, onCreateBlank }: TemplatePickerMo
                 haptic('light');
                 onCreateBlank();
               }}
-              className="w-full flex items-center gap-4 p-4 bg-gradient-to-r from-amber-50 to-orange-50 dark:from-amber-900/20 dark:to-orange-900/20 border-2 border-dashed border-amber-300 dark:border-amber-700 rounded-xl hover:border-amber-400 dark:hover:border-amber-600 transition-colors text-left"
+              className="w-full flex items-center gap-4 p-4 bg-amber-50 dark:bg-amber-900/20 border-2 border-dashed border-amber-300 dark:border-amber-700 rounded-xl hover:border-amber-400 dark:hover:border-amber-600 transition-colors text-left"
             >
               <span className="text-2xl leading-none">✨</span>
               <div>

--- a/src/components/offline/OfflineIndicator.tsx
+++ b/src/components/offline/OfflineIndicator.tsx
@@ -48,7 +48,7 @@ export function OfflineIndicator() {
 
   return (
     <div className="fixed top-0 left-0 right-0 z-50 safe-area-top" role="alert" aria-live="assertive">
-      <div className="bg-gradient-to-r from-amber-500 to-orange-500 text-white px-4 py-2.5 text-center text-sm font-medium shadow-lg">
+      <div className="bg-amber-500 text-white px-4 py-2.5 text-center text-sm font-medium shadow-lg">
         <div className="flex items-center justify-center gap-2">
           <span className="relative flex h-3 w-3">
             <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-white opacity-75"></span>

--- a/src/components/publish/PublishModal.tsx
+++ b/src/components/publish/PublishModal.tsx
@@ -169,7 +169,7 @@ export function PublishModal({ list, onClose }: PublishModalProps) {
       <button
         onClick={handlePublish}
         disabled={isPublishing}
-        className="flex-1 px-4 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 transition-all"
+        className="flex-1 px-4 py-3 bg-amber-500 hover:bg-amber-400 text-white rounded-xl font-semibold shadow-lg shadow-amber-500/25 disabled:opacity-50 transition-all"
       >
         {isPublishing ? (
           <span className="flex items-center justify-center gap-2">

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,12 +1,11 @@
 /**
- * Empty state components with playful Poo App branding.
+ * Empty state components — Boop design.
  */
 
 import { type ReactNode } from 'react';
 
 interface EmptyStateProps {
   icon?: ReactNode;
-  emoji?: string;
   title: string;
   description: string;
   action?: ReactNode;
@@ -15,27 +14,51 @@ interface EmptyStateProps {
 /**
  * Generic empty state component.
  */
-export function EmptyState({ icon, emoji = '💩', title, description, action }: EmptyStateProps) {
+export function EmptyState({ icon, title, description, action }: EmptyStateProps) {
   return (
-    <div className="text-center py-16 px-6 bg-gradient-to-b from-amber-50 to-orange-50 dark:from-gray-800 dark:to-gray-900 rounded-3xl border-2 border-dashed border-amber-200 dark:border-gray-700">
+    <div
+      className="text-center py-14 px-6 rounded-3xl border-2 border-dashed border-stone-200 dark:border-stone-700"
+      style={{ background: 'var(--boop-panel)' }}
+    >
       <div className="relative inline-block mb-6">
         {icon || (
-          <div className="text-7xl animate-bounce-slow filter drop-shadow-lg">
-            {emoji}
+          <div
+            className="rounded-full mx-auto flex items-center justify-center"
+            style={{
+              width: 88,
+              height: 88,
+              background: 'var(--boop-accent-soft)',
+            }}
+          >
+            <div
+              className="rounded-full"
+              style={{
+                width: 40,
+                height: 40,
+                background: 'var(--boop-accent)',
+                animation: 'pulse-ring 2.4s ease-in-out infinite',
+              }}
+              aria-hidden="true"
+            />
           </div>
         )}
-        {/* Floating particles */}
-        <div className="absolute -top-2 -right-2 text-2xl animate-float-delayed">✨</div>
-        <div className="absolute -bottom-1 -left-3 text-xl animate-float">🌟</div>
       </div>
-      
-      <h3 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+
+      <h3
+        className="text-stone-900 dark:text-stone-50 mb-2"
+        style={{
+          fontFamily: 'Nunito, system-ui, sans-serif',
+          fontWeight: 700,
+          fontSize: 22,
+          letterSpacing: -0.6,
+        }}
+      >
         {title}
       </h3>
-      <p className="text-gray-600 dark:text-gray-400 max-w-sm mx-auto mb-6">
+      <p className="text-stone-500 dark:text-stone-400 max-w-sm mx-auto mb-6 text-sm leading-relaxed">
         {description}
       </p>
-      
+
       {action}
     </div>
   );
@@ -47,16 +70,18 @@ export function EmptyState({ icon, emoji = '💩', title, description, action }:
 export function NoListsEmptyState({ onCreateList }: { onCreateList: () => void }) {
   return (
     <EmptyState
-      emoji="📝"
-      title="No lists yet!"
-      description="Create your first list and start organizing your life. Every great journey starts with a single step... or a single list."
+      title="Nothing here yet."
+      description="Make a list for the thing you keep meaning to do. One is enough to start."
       action={
         <button
           onClick={onCreateList}
-          className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-amber-500 to-orange-500 hover:from-amber-400 hover:to-orange-400 text-white rounded-2xl font-bold text-lg shadow-lg shadow-amber-500/30 hover:shadow-xl hover:shadow-amber-500/40 transition-all hover:-translate-y-0.5 active:translate-y-0"
+          className="inline-flex items-center gap-2 px-5 py-2.5 rounded-full font-semibold text-white text-sm transition-transform active:scale-95"
+          style={{
+            background: 'var(--boop-accent)',
+            boxShadow: '0 8px 20px rgba(107,60,255,0.35)',
+          }}
         >
-          <span>💩</span>
-          Create Your First List
+          Make your first list
         </button>
       }
     />
@@ -69,12 +94,28 @@ export function NoListsEmptyState({ onCreateList }: { onCreateList: () => void }
 export function NoItemsEmptyState() {
   return (
     <div className="py-12 px-6 text-center">
-      <div className="text-5xl mb-4 animate-bounce-slow">📋</div>
-      <h3 className="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-1">
+      <div
+        className="rounded-full mx-auto mb-4"
+        style={{
+          width: 44,
+          height: 44,
+          background: 'var(--boop-accent-soft)',
+        }}
+        aria-hidden="true"
+      />
+      <h3
+        className="text-stone-700 dark:text-stone-200 mb-1"
+        style={{
+          fontFamily: 'Nunito, system-ui, sans-serif',
+          fontWeight: 700,
+          fontSize: 18,
+          letterSpacing: -0.4,
+        }}
+      >
         This list is empty
       </h3>
-      <p className="text-gray-500 dark:text-gray-400 text-sm">
-        Add your first item below to get started!
+      <p className="text-stone-500 dark:text-stone-400 text-sm">
+        Add your first item below to get started.
       </p>
     </div>
   );
@@ -86,9 +127,8 @@ export function NoItemsEmptyState() {
 export function NoSearchResultsEmptyState({ query }: { query: string }) {
   return (
     <EmptyState
-      emoji="🔍"
-      title="No matches found"
-      description={`We couldn't find any lists matching "${query}". Try a different search term!`}
+      title="Nothing matches."
+      description={`No lists matching "${query}". Try a different search term.`}
     />
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
-@import "tailwindcss";
 @import url('https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&family=Nunito:wght@500;600;700;800;900&display=swap');
+@import "tailwindcss";
 
 /* Tailwind v4 class-based dark mode variant */
 @custom-variant dark (&:where(.dark, .dark *));

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,28 @@
 @import "tailwindcss";
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&family=Nunito:wght@500;600;700;800;900&display=swap');
 
 /* Tailwind v4 class-based dark mode variant */
 @custom-variant dark (&:where(.dark, .dark *));
+
+/* Boop brand — remap amber palette to electric violet so the existing
+   amber-* utility classes across the app render in the new accent color. */
+@theme {
+  --font-sans: 'Geist', 'Inter', system-ui, sans-serif;
+  --font-rounded: 'Nunito', system-ui, sans-serif;
+  --font-mono: 'Geist Mono', ui-monospace, monospace;
+
+  --color-amber-50: #f6f2ff;
+  --color-amber-100: #ece4ff;
+  --color-amber-200: #dcceff;
+  --color-amber-300: #c2a8ff;
+  --color-amber-400: #9b74ff;
+  --color-amber-500: #6b3cff;
+  --color-amber-600: #5a2fe8;
+  --color-amber-700: #4723b3;
+  --color-amber-800: #341881;
+  --color-amber-900: #2a1570;
+  --color-amber-950: #1a0a4d;
+}
 
 /* Safe area insets for native mobile */
 :root {
@@ -10,20 +31,30 @@
   --safe-area-left: env(safe-area-inset-left, 0px);
   --safe-area-right: env(safe-area-inset-right, 0px);
 
-  /* Warm Cream/Amber Design System - 💩 Brand Colors */
-  /* Backgrounds - Cream tones */
-  --cream-50: #fffcf5;
-  --cream-100: #fef8ed;
-  --cream-200: #fcefd5;
-  --cream-300: #fae5bd;
-  
-  /* Amber Accents - Primary interactive colors */
-  --amber-400: #fbbf24;
-  --amber-500: #f59e0b;
-  --amber-600: #d97706;
-  --amber-700: #b45309;
-  --amber-800: #92400e;
-  --amber-900: #78350f;
+  /* Boop brand tokens */
+  --boop-bg: #fafaf7;
+  --boop-card: #ffffff;
+  --boop-panel: #f4f3ee;
+  --boop-ink: #111014;
+  --boop-muted: #6b6a74;
+  --boop-dim: #a8a7b0;
+  --boop-line: #ecebe6;
+  --boop-accent: #6b3cff;
+  --boop-accent-soft: #ece4ff;
+  --boop-accent-ink: #2a1570;
+
+  /* Legacy aliases retained so any direct var() consumers keep working. */
+  --cream-50: var(--boop-bg);
+  --cream-100: #f4f3ee;
+  --cream-200: #ece4ff;
+  --cream-300: #dcceff;
+
+  --amber-400: #9b74ff;
+  --amber-500: #6b3cff;
+  --amber-600: #5a2fe8;
+  --amber-700: #4723b3;
+  --amber-800: #341881;
+  --amber-900: #2a1570;
   
   /* Warm Neutrals - Replacing grays */
   --warm-50: #fafaf9;
@@ -299,7 +330,7 @@ html, body {
 /* Touch-friendly tap highlights */
 @media (hover: none) and (pointer: coarse) {
   button, a, [role="button"] {
-    -webkit-tap-highlight-color: rgba(245, 158, 11, 0.2);
+    -webkit-tap-highlight-color: rgba(107, 60, 255, 0.2);
   }
 }
 
@@ -343,8 +374,29 @@ html {
 
 /* Focus visible styles for accessibility */
 :focus-visible {
-  outline: 2px solid rgb(245, 158, 11);
+  outline: 2px solid #6b3cff;
   outline-offset: 2px;
+}
+
+/* Boop wordmark + dot primitives */
+.boop-wordmark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  font-family: var(--font-rounded);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 1;
+  color: var(--boop-ink);
+}
+.dark .boop-wordmark { color: #f1eef9; }
+.boop-dot {
+  display: inline-block;
+  width: 0.73em;
+  height: 0.73em;
+  border-radius: 50%;
+  background: var(--boop-accent);
+  flex: none;
 }
 
 /* Hide focus ring for mouse users */

--- a/src/lib/biometrics.ts
+++ b/src/lib/biometrics.ts
@@ -34,7 +34,7 @@ class NativeBiometric implements BiometricService {
     const plugin = await this.getPlugin();
     if (!plugin) return false;
     try {
-      await plugin.verifyIdentity({ reason, title: 'Poo App' });
+      await plugin.verifyIdentity({ reason, title: 'boop' });
       return true;
     } catch { return false; }
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,6 +13,7 @@ import { initNetworkMonitoring } from './lib/network'
 import { initAnalyticsIfConsented } from './components/CookieConsent'
 import { initSentry } from './lib/sentry'
 import './index.css'
+import './pages/Landing.css'
 import App from './App.tsx'
 
 // Initialize Sentry before anything else (no-op if VITE_SENTRY_DSN is not set)

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -25,12 +25,12 @@ const COMPETITORS: Record<string, CompetitorData> = {
   todoist: {
     name: 'Todoist',
     slug: 'todoist',
-    tagline: 'Poo App vs Todoist',
-    metaTitle: 'Poo App vs Todoist — The Better Todoist Alternative',
+    tagline: 'boop vs Todoist',
+    metaTitle: 'boop vs Todoist — The Better Todoist Alternative',
     metaDescription:
-      'Comparing Poo App vs Todoist: offline-first access, real-time collaboration, DID-signed data ownership, and a free tier that actually works. See why teams are switching.',
+      'Comparing boop vs Todoist: offline-first access, real-time collaboration, DID-signed data ownership, and a free tier that actually works. See why teams are switching.',
     ogDescription:
-      'Poo App vs Todoist — offline-first, real-time sync, and data you actually own. Free to start.',
+      'boop vs Todoist — offline-first, real-time sync, and data you actually own. Free to start.',
     pooHeadline: 'Offline-first. Data you own. Free to start.',
     competitorHeadline: 'Todoist requires a connection and a credit card for collaboration.',
     features: [
@@ -54,12 +54,12 @@ const COMPETITORS: Record<string, CompetitorData> = {
   reminders: {
     name: 'Apple Reminders',
     slug: 'reminders',
-    tagline: 'Poo App vs Apple Reminders',
-    metaTitle: 'Poo App vs Apple Reminders — Better Cross-Platform Todo App',
+    tagline: 'boop vs Apple Reminders',
+    metaTitle: 'boop vs Apple Reminders — Better Cross-Platform Todo App',
     metaDescription:
-      'Comparing Poo App vs Apple Reminders: real-time sync across all platforms, full offline support, and list sharing without an Apple device. Free to start.',
+      'Comparing boop vs Apple Reminders: real-time sync across all platforms, full offline support, and list sharing without an Apple device. Free to start.',
     ogDescription:
-      'Poo App vs Apple Reminders — works on Android, Windows, and web. Real-time sync. Free.',
+      'boop vs Apple Reminders — works on Android, Windows, and web. Real-time sync. Free.',
     pooHeadline: 'Cross-platform. Real-time. No Apple required.',
     competitorHeadline: 'Apple Reminders only works if everyone you share with owns Apple devices.',
     features: [
@@ -83,12 +83,12 @@ const COMPETITORS: Record<string, CompetitorData> = {
   things: {
     name: 'Things 3',
     slug: 'things',
-    tagline: 'Poo App vs Things 3',
-    metaTitle: 'Poo App vs Things 3 — Free Alternative with Real-Time Sharing',
+    tagline: 'boop vs Things 3',
+    metaTitle: 'boop vs Things 3 — Free Alternative with Real-Time Sharing',
     metaDescription:
-      'Comparing Poo App vs Things 3: free to start, real-time collaboration, cross-platform, and no $50 Mac app purchase. See why Poo App is the modern Things alternative.',
+      'Comparing boop vs Things 3: free to start, real-time collaboration, cross-platform, and no $50 Mac app purchase. See why boop is the modern Things alternative.',
     ogDescription:
-      'Poo App vs Things 3 — free to start, real-time sharing, works on Android and web. No $50 upfront.',
+      'boop vs Things 3 — free to start, real-time sharing, works on Android and web. No $50 upfront.',
     pooHeadline: 'Free to start. Real-time. Works everywhere.',
     competitorHeadline: 'Things 3 costs $50 for Mac, has no Android app, and has zero collaboration.',
     features: [
@@ -164,7 +164,7 @@ export function Compare() {
     setMeta('twitter:description', data.ogDescription)
 
     return () => {
-      document.title = '💩 Poo App - Organize Your Life'
+      document.title = 'boop'
     }
   }, [data])
 
@@ -172,9 +172,13 @@ export function Compare() {
     return (
       <div className="min-h-screen bg-amber-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="text-6xl mb-4">💩</div>
+          <div
+            className="mx-auto mb-5 rounded-full"
+            style={{ width: 48, height: 48, background: 'var(--boop-accent)' }}
+            aria-hidden="true"
+          />
           <h1 className="text-2xl font-bold text-amber-900 mb-2">Comparison not found</h1>
-          <a href="/" className="text-amber-600 underline">Back to Poo App</a>
+          <a href="/" className="text-amber-600 underline">Back to boop</a>
         </div>
       </div>
     )
@@ -186,10 +190,14 @@ export function Compare() {
       <header className="bg-amber-900 text-amber-50 py-8 px-4">
         <div className="max-w-4xl mx-auto">
           <a href="/" className="flex items-center gap-2 mb-6 text-amber-200 hover:text-white transition-colors text-sm">
-            &larr; Back to Poo App
+            &larr; Back to boop
           </a>
           <div className="flex items-center gap-3 mb-3">
-            <span className="text-4xl">💩</span>
+            <span
+              className="rounded-full"
+              style={{ width: 28, height: 28, background: 'var(--boop-accent)', display: 'inline-block' }}
+              aria-hidden="true"
+            />
             <h1 className="text-3xl md:text-4xl font-black">{data.tagline}</h1>
           </div>
           <p className="text-amber-200 text-lg max-w-2xl">{data.pooHeadline}</p>
@@ -213,7 +221,12 @@ export function Compare() {
                   <th className="text-left px-4 py-3 font-semibold w-1/2">Feature</th>
                   <th className="text-center px-4 py-3 font-semibold w-1/4">
                     <span className="flex items-center justify-center gap-1.5">
-                      <span>💩</span> Poo App
+                      <span
+                        className="rounded-full"
+                        style={{ width: 10, height: 10, background: '#fff', display: 'inline-block' }}
+                        aria-hidden="true"
+                      />
+                      boop
                     </span>
                   </th>
                   <th className="text-center px-4 py-3 font-semibold w-1/4">{data.name}</th>
@@ -241,7 +254,11 @@ export function Compare() {
 
         {/* CTA */}
         <section className="bg-amber-900 text-amber-50 rounded-2xl px-8 py-10 text-center shadow-lg">
-          <div className="text-5xl mb-4">💩</div>
+          <div
+            className="mx-auto mb-5 rounded-full"
+            style={{ width: 44, height: 44, background: 'var(--boop-accent)' }}
+            aria-hidden="true"
+          />
           <h2 className="text-2xl md:text-3xl font-black mb-3">
             Ready to ditch {data.name}?
           </h2>
@@ -252,7 +269,7 @@ export function Compare() {
             href="/"
             className="inline-block bg-amber-400 hover:bg-amber-300 text-amber-900 font-bold text-lg px-8 py-3 rounded-xl transition-colors shadow"
           >
-            Try Poo App Free
+            Try boop Free
           </a>
           <p className="text-amber-300 text-sm mt-4">
             Free forever for up to 5 lists. No credit card needed.
@@ -271,7 +288,7 @@ export function Compare() {
                   href={`/compare/${c.slug}`}
                   className="px-4 py-2 bg-amber-100 hover:bg-amber-200 text-amber-800 font-medium rounded-lg transition-colors text-sm border border-amber-200"
                 >
-                  Poo App vs {c.name} &rarr;
+                  boop vs {c.name} &rarr;
                 </a>
               ))}
           </div>
@@ -280,7 +297,10 @@ export function Compare() {
 
       <footer className="border-t border-amber-200 py-6 px-4 text-center text-amber-600 text-sm mt-4">
         <p>
-          <a href="/" className="hover:text-amber-900 transition-colors font-semibold">💩 Poo App</a>
+          <a href="/" className="boop-wordmark hover:opacity-80 transition-opacity" aria-label="boop">
+            <span className="boop-dot" aria-hidden="true" style={{ width: 10, height: 10 }} />
+            <span>boop</span>
+          </a>
           {' · '}
           <a href="/pricing" className="hover:text-amber-900 transition-colors">Pricing</a>
           {' · '}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -285,64 +285,64 @@ export function Home() {
 
   return (
     <div className="min-h-full pb-28">
-      {/* Top bar — streak + profile avatar */}
-      <div className="flex items-center justify-end gap-2.5 pt-2 pb-5">
-        {streak > 0 && <StreakBadge streak={streak} />}
-        <Link
-          to="/profile"
-          onClick={() => haptic('light')}
-          aria-label="Profile"
-          className="flex items-center justify-center w-[34px] h-[34px] rounded-full text-white font-extrabold text-sm active:scale-95 transition-transform"
-          style={{
-            background: 'var(--boop-accent)',
-            fontFamily: 'Nunito, system-ui, sans-serif',
-            letterSpacing: -0.3,
-          }}
-        >
-          {(did ?? 'r').slice(-1).toUpperCase() || 'R'}
-        </Link>
-      </div>
-
-      {/* Greeting hero */}
-      <div className="pb-5">
-        <h1
-          className="text-stone-900 dark:text-stone-50"
-          style={{
-            fontFamily: 'Nunito, system-ui, sans-serif',
-            fontWeight: 700,
-            fontSize: 'clamp(30px, 5.5vw, 40px)',
-            letterSpacing: -1.2,
-            lineHeight: 1.05,
-            margin: 0,
-          }}
-        >
-          {hasLists ? <>Your lists —<br /><span className="text-stone-500 dark:text-stone-400" style={{ fontWeight: 600 }}>what's on today?</span></> : <>Welcome in,<br /><span className="text-stone-500 dark:text-stone-400" style={{ fontWeight: 600 }}>let's make your first list.</span></>}
-        </h1>
-        {hasLists && (
-          <div
-            className="flex items-center gap-3.5 flex-wrap mt-3 text-[13px] text-stone-500 dark:text-stone-400"
+      {/* Greeting hero with streak + profile avatar inline on the right */}
+      <div className="flex items-start justify-between gap-3 pt-2 pb-5">
+        <div className="flex-1 min-w-0">
+          <h1
+            className="text-stone-900 dark:text-stone-50"
+            style={{
+              fontFamily: 'Nunito, system-ui, sans-serif',
+              fontWeight: 700,
+              fontSize: 'clamp(30px, 5.5vw, 40px)',
+              letterSpacing: -1.2,
+              lineHeight: 1.05,
+              margin: 0,
+            }}
           >
-            <span>
-              <b className="text-stone-900 dark:text-stone-100">{totalListCount}</b> {totalListCount === 1 ? 'list' : 'lists'}
-            </span>
-            {allSharedLists.length > 0 && (
-              <>
-                <span className="text-stone-300 dark:text-stone-600">·</span>
-                <span>
-                  <b className="text-stone-900 dark:text-stone-100">{allSharedLists.length}</b> shared
-                </span>
-              </>
-            )}
-            {favouriteLists.length > 0 && (
-              <>
-                <span className="text-stone-300 dark:text-stone-600">·</span>
-                <span>
-                  <b className="text-stone-900 dark:text-stone-100">{favouriteLists.length}</b> pinned
-                </span>
-              </>
-            )}
-          </div>
-        )}
+            {hasLists ? <>Your lists —<br /><span className="text-stone-500 dark:text-stone-400" style={{ fontWeight: 600 }}>what's on today?</span></> : <>Welcome in,<br /><span className="text-stone-500 dark:text-stone-400" style={{ fontWeight: 600 }}>let's make your first list.</span></>}
+          </h1>
+          {hasLists && (
+            <div
+              className="flex items-center gap-3.5 flex-wrap mt-3 text-[13px] text-stone-500 dark:text-stone-400"
+            >
+              <span>
+                <b className="text-stone-900 dark:text-stone-100">{totalListCount}</b> {totalListCount === 1 ? 'list' : 'lists'}
+              </span>
+              {allSharedLists.length > 0 && (
+                <>
+                  <span className="text-stone-300 dark:text-stone-600">·</span>
+                  <span>
+                    <b className="text-stone-900 dark:text-stone-100">{allSharedLists.length}</b> shared
+                  </span>
+                </>
+              )}
+              {favouriteLists.length > 0 && (
+                <>
+                  <span className="text-stone-300 dark:text-stone-600">·</span>
+                  <span>
+                    <b className="text-stone-900 dark:text-stone-100">{favouriteLists.length}</b> pinned
+                  </span>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-2.5 flex-shrink-0">
+          {streak > 0 && <StreakBadge streak={streak} />}
+          <Link
+            to="/profile"
+            onClick={() => haptic('light')}
+            aria-label="Profile"
+            className="flex items-center justify-center w-[34px] h-[34px] rounded-full text-white font-extrabold text-sm active:scale-95 transition-transform"
+            style={{
+              background: 'var(--boop-accent)',
+              fontFamily: 'Nunito, system-ui, sans-serif',
+              letterSpacing: -0.3,
+            }}
+          >
+            {(did ?? 'r').slice(-1).toUpperCase() || 'R'}
+          </Link>
+        </div>
       </div>
 
       {/* Search + New button — inline pill row */}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -408,7 +408,7 @@ export function Home() {
 
       {/* Referral CTA — shown to free users who have lists */}
       {!isLoading && hasLists && !isPro && (
-        <div className="mb-6 p-4 bg-gradient-to-r from-amber-50 to-orange-50 dark:from-amber-950/30 dark:to-orange-950/20 border border-amber-200/60 dark:border-amber-800/40 rounded-2xl animate-slide-up">
+        <div className="mb-6 p-4 bg-amber-50 dark:bg-amber-950/30 border border-amber-200/60 dark:border-amber-800/40 rounded-2xl animate-slide-up">
           <ReferralInviteCurrentUser compact />
         </div>
       )}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -285,28 +285,22 @@ export function Home() {
 
   return (
     <div className="min-h-full pb-28">
-      {/* Top bar — wordmark + profile avatar */}
-      <div className="flex items-center justify-between pt-2 pb-5">
-        <div className="boop-wordmark text-[22px] sm:text-[26px] leading-none">
-          <span className="boop-dot" aria-hidden="true" />
-          <span>boop</span>
-        </div>
-        <div className="flex items-center gap-2.5">
-          {streak > 0 && <StreakBadge streak={streak} />}
-          <Link
-            to="/profile"
-            onClick={() => haptic('light')}
-            aria-label="Profile"
-            className="flex items-center justify-center w-[34px] h-[34px] rounded-full text-white font-extrabold text-sm active:scale-95 transition-transform"
-            style={{
-              background: 'var(--boop-accent)',
-              fontFamily: 'Nunito, system-ui, sans-serif',
-              letterSpacing: -0.3,
-            }}
-          >
-            {(did ?? 'r').slice(-1).toUpperCase() || 'R'}
-          </Link>
-        </div>
+      {/* Top bar — streak + profile avatar */}
+      <div className="flex items-center justify-end gap-2.5 pt-2 pb-5">
+        {streak > 0 && <StreakBadge streak={streak} />}
+        <Link
+          to="/profile"
+          onClick={() => haptic('light')}
+          aria-label="Profile"
+          className="flex items-center justify-center w-[34px] h-[34px] rounded-full text-white font-extrabold text-sm active:scale-95 transition-transform"
+          style={{
+            background: 'var(--boop-accent)',
+            fontFamily: 'Nunito, system-ui, sans-serif',
+            letterSpacing: -0.3,
+          }}
+        >
+          {(did ?? 'r').slice(-1).toUpperCase() || 'R'}
+        </Link>
       </div>
 
       {/* Greeting hero */}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -96,7 +96,7 @@ export function Home() {
     }
   }, [isOnline, serverLists]);
 
-  // Step 1: auto-create "Getting Started 💩" demo list for new users
+  // Step 1: auto-create "Getting Started" demo list for new users
   useEffect(() => {
     if (demoStarted || demoCreatingRef.current) return;
     if (!did || serverLists === undefined) return;
@@ -115,17 +115,17 @@ export function Home() {
 
     const createDemo = async () => {
       try {
-        const listAsset = await createListAsset("Getting Started 💩", did);
+        const listAsset = await createListAsset("Getting Started", did);
         const listId = await createList({
           assetDid: listAsset.assetDid,
-          name: "Getting Started 💩",
+          name: "Getting Started",
           ownerDid: did,
           createdAt: Date.now(),
         });
         const demoItems = [
-          "Add your first item 💩",
-          "Share this list with someone 🤝",
-          "Check off a task ✅",
+          "Add your first item",
+          "Share this list with someone",
+          "Check off a task",
         ];
         for (const name of demoItems) {
           await addItem({
@@ -285,30 +285,105 @@ export function Home() {
 
   return (
     <div className="min-h-full pb-28">
-      {/* Header */}
-      <div className="pt-2 pb-6">
-        <div className="flex items-end justify-between mb-4">
-          <div>
-            <div className="flex items-center gap-3">
-              <h1 className="text-[2rem] sm:text-4xl font-extrabold text-stone-900 dark:text-stone-50 tracking-tight leading-none">
-                Your Lists
-              </h1>
-              {streak > 0 && <StreakBadge streak={streak} />}
-            </div>
-            {hasLists && (
-              <p className="mt-1.5 text-sm font-medium text-stone-400 dark:text-stone-500">
-                {totalListCount} {totalListCount === 1 ? 'list' : 'lists'}
-              </p>
+      {/* Top bar — wordmark + profile avatar */}
+      <div className="flex items-center justify-between pt-2 pb-5">
+        <div className="boop-wordmark text-[22px] sm:text-[26px] leading-none">
+          <span className="boop-dot" aria-hidden="true" />
+          <span>boop</span>
+        </div>
+        <div className="flex items-center gap-2.5">
+          {streak > 0 && <StreakBadge streak={streak} />}
+          <Link
+            to="/profile"
+            onClick={() => haptic('light')}
+            aria-label="Profile"
+            className="flex items-center justify-center w-[34px] h-[34px] rounded-full text-white font-extrabold text-sm active:scale-95 transition-transform"
+            style={{
+              background: 'var(--boop-accent)',
+              fontFamily: 'Nunito, system-ui, sans-serif',
+              letterSpacing: -0.3,
+            }}
+          >
+            {(did ?? 'r').slice(-1).toUpperCase() || 'R'}
+          </Link>
+        </div>
+      </div>
+
+      {/* Greeting hero */}
+      <div className="pb-5">
+        <h1
+          className="text-stone-900 dark:text-stone-50"
+          style={{
+            fontFamily: 'Nunito, system-ui, sans-serif',
+            fontWeight: 700,
+            fontSize: 'clamp(30px, 5.5vw, 40px)',
+            letterSpacing: -1.2,
+            lineHeight: 1.05,
+            margin: 0,
+          }}
+        >
+          {hasLists ? <>Your lists —<br /><span className="text-stone-500 dark:text-stone-400" style={{ fontWeight: 600 }}>what's on today?</span></> : <>Welcome in,<br /><span className="text-stone-500 dark:text-stone-400" style={{ fontWeight: 600 }}>let's make your first list.</span></>}
+        </h1>
+        {hasLists && (
+          <div
+            className="flex items-center gap-3.5 flex-wrap mt-3 text-[13px] text-stone-500 dark:text-stone-400"
+          >
+            <span>
+              <b className="text-stone-900 dark:text-stone-100">{totalListCount}</b> {totalListCount === 1 ? 'list' : 'lists'}
+            </span>
+            {allSharedLists.length > 0 && (
+              <>
+                <span className="text-stone-300 dark:text-stone-600">·</span>
+                <span>
+                  <b className="text-stone-900 dark:text-stone-100">{allSharedLists.length}</b> shared
+                </span>
+              </>
+            )}
+            {favouriteLists.length > 0 && (
+              <>
+                <span className="text-stone-300 dark:text-stone-600">·</span>
+                <span>
+                  <b className="text-stone-900 dark:text-stone-100">{favouriteLists.length}</b> pinned
+                </span>
+              </>
             )}
           </div>
-        </div>
+        )}
+      </div>
 
-        {/* Quick Actions - pill chips */}
-        <div className="flex items-center gap-2.5">
+      {/* Search + New button — inline pill row */}
+      {hasLists && (
+        <div className="flex gap-2.5 mb-3 items-center">
+          <div className="flex-1 min-w-0">
+            <SearchInput
+              value={searchQuery}
+              onChange={setSearchQuery}
+              className="w-full"
+            />
+          </div>
+          <button
+            onClick={handleOpenCreate}
+            className="inline-flex items-center gap-1.5 flex-shrink-0 px-3.5 py-2 rounded-full text-[13px] font-semibold text-white active:scale-95 transition-transform whitespace-nowrap"
+            style={{
+              background: 'var(--boop-accent)',
+              boxShadow: '0 4px 14px rgba(107,60,255,0.3)',
+            }}
+          >
+            <svg width="12" height="12" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+              <path d="M7 2v10M2 7h10" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+            </svg>
+            <span>New</span>
+          </button>
+        </div>
+      )}
+
+      {/* Secondary row — Focus, Categories, Sort */}
+      {hasLists && (
+        <div className="flex items-center gap-2 mb-5 flex-wrap">
           <Link
             to="/priority"
             onClick={() => haptic('light')}
-            className="inline-flex items-center gap-1.5 text-[13px] text-amber-700 dark:text-amber-400 pl-3 pr-3.5 py-2 rounded-full font-semibold bg-amber-50 dark:bg-amber-950/40 hover:bg-amber-100 dark:hover:bg-amber-900/50 border border-amber-200/60 dark:border-amber-800/50 transition-all active:scale-95"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium text-stone-600 dark:text-stone-300 bg-stone-100 dark:bg-stone-800/60 hover:bg-stone-200 dark:hover:bg-stone-800 transition-colors"
           >
             <span>🎯</span>
             <span>Focus</span>
@@ -318,30 +393,14 @@ export function Home() {
               haptic('light');
               setIsCategoryManagerOpen(true);
             }}
-            className="inline-flex items-center gap-1.5 text-[13px] text-stone-600 dark:text-stone-400 pl-3 pr-3.5 py-2 rounded-full font-semibold bg-stone-100 dark:bg-stone-800/60 hover:bg-stone-200 dark:hover:bg-stone-800 border border-stone-200/60 dark:border-stone-700/50 transition-all active:scale-95"
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-[12px] font-medium text-stone-600 dark:text-stone-300 bg-stone-100 dark:bg-stone-800/60 hover:bg-stone-200 dark:hover:bg-stone-800 transition-colors"
           >
             <span>📁</span>
             <span>Categories</span>
           </button>
-          <button
-            onClick={handleOpenCreate}
-            className="inline-flex items-center gap-1.5 text-[13px] text-amber-900 dark:text-amber-100 pl-3 pr-3.5 py-2 rounded-full font-semibold bg-amber-400/90 dark:bg-amber-500/80 hover:bg-amber-300 dark:hover:bg-amber-400 border border-amber-500/70 dark:border-amber-400/70 shadow-sm shadow-amber-500/30 transition-all active:scale-95"
-          >
-            <span>➕</span>
-            <span>New list</span>
-          </button>
-        </div>
-      </div>
-
-      {/* Search and Sort */}
-      {hasLists && (
-        <div className="relative z-20 flex gap-2.5 mb-6 animate-slide-up">
-          <SearchInput
-            value={searchQuery}
-            onChange={setSearchQuery}
-            className="flex-1"
-          />
-          <SortDropdown />
+          <div className="ml-auto">
+            <SortDropdown />
+          </div>
         </div>
       )}
 

--- a/src/pages/InviteLanding.tsx
+++ b/src/pages/InviteLanding.tsx
@@ -31,10 +31,14 @@ export function InviteLanding() {
   }, [code, isAuthenticated, navigate]);
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-amber-50 via-orange-50 to-amber-100 flex items-center justify-center p-4">
+    <div className="min-h-screen flex items-center justify-center p-4" style={{ background: 'var(--boop-bg)' }}>
       <div className="text-center">
-        <div className="text-6xl mb-4">💩</div>
-        <p className="text-amber-800 font-medium">Getting your invite ready…</p>
+        <div
+          className="mx-auto mb-5 rounded-full animate-pulse-ring"
+          style={{ width: 56, height: 56, background: 'var(--boop-accent)' }}
+          aria-hidden="true"
+        />
+        <p className="text-stone-600 dark:text-stone-300 font-medium">Getting your invite ready…</p>
       </div>
     </div>
   );

--- a/src/pages/Landing.css
+++ b/src/pages/Landing.css
@@ -1,0 +1,180 @@
+.boop-landing {
+  --bg: #fafaf7;
+  --card: #ffffff;
+  --panel: #f4f3ee;
+  --ink: #111014;
+  --muted: #6b6a74;
+  --dim: #a8a7b0;
+  --line: #ecebe6;
+  --lineSoft: #f3f2ec;
+  --accent: #6b3cff;
+  --accentSoft: #ece4ff;
+  --accentInk: #2a1570;
+  --ok: #1a7a4c;
+  --sans: 'Geist', 'Inter', system-ui, sans-serif;
+  --rounded: 'Nunito', system-ui, sans-serif;
+  --mono: 'Geist Mono', ui-monospace, monospace;
+
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--sans);
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+  min-height: 100vh;
+}
+.boop-landing * { box-sizing: border-box; }
+.boop-landing button { font: inherit; cursor: pointer; }
+.boop-landing a { color: inherit; text-decoration: none; }
+.boop-landing kbd { font-family: var(--mono); font-size: 0.85em; background: var(--panel); border: 1px solid var(--line); padding: 1px 6px; border-radius: 4px; }
+
+.boop-landing .wrap { max-width: 1180px; margin: 0 auto; padding: 0 32px; }
+@media (max-width: 720px) { .boop-landing .wrap { padding: 0 20px; } }
+
+.boop-landing .nav { position: sticky; top: 0; z-index: 20; backdrop-filter: blur(14px); background: rgba(250,250,247,0.75); border-bottom: 1px solid var(--lineSoft); }
+.boop-landing .nav-inner { display: flex; align-items: center; justify-content: space-between; height: 64px; }
+.boop-landing .wordmark { display: inline-flex; align-items: center; gap: 8px; font-family: var(--rounded); font-weight: 800; font-size: 22px; letter-spacing: -0.8px; color: var(--ink); white-space: nowrap; }
+.boop-landing .wordmark .dot { width: 16px; height: 16px; border-radius: 50%; background: var(--accent); flex-shrink: 0; }
+.boop-landing .wordmark-sm { font-size: 18px; gap: 6px; }
+.boop-landing .wordmark-sm .dot { width: 13px; height: 13px; }
+.boop-landing .nav-links { display: flex; gap: 28px; font-size: 14px; color: var(--muted); }
+.boop-landing .nav-links a:hover { color: var(--ink); }
+.boop-landing .nav-cta { display: flex; gap: 10px; align-items: center; }
+.boop-landing .btn { border: none; border-radius: 999px; padding: 10px 18px; font-size: 14px; font-weight: 600; font-family: var(--sans); white-space: nowrap; transition: transform 120ms, box-shadow 120ms, background 120ms; display: inline-flex; align-items: center; justify-content: center; }
+.boop-landing .btn-primary { background: var(--accent); color: #fff; box-shadow: 0 6px 18px rgba(107,60,255,0.3); }
+.boop-landing .btn-primary:hover { transform: translateY(-1px); box-shadow: 0 10px 24px rgba(107,60,255,0.38); }
+.boop-landing .btn-ghost { background: transparent; color: var(--ink); border: 1px solid var(--line); }
+.boop-landing .btn-ghost:hover { background: var(--panel); }
+@media (max-width: 820px) { .boop-landing .nav-links { display: none; } }
+
+.boop-landing .hero { padding: 64px 0 60px; position: relative; }
+.boop-landing .hero h1 { display: flex; align-items: center; gap: clamp(14px, 1.4vw, 20px); flex-wrap: nowrap; font-family: var(--rounded); font-weight: 900; font-size: clamp(48px, 8vw, 108px); letter-spacing: -3px; line-height: 0.95; margin: 0 0 24px; max-width: 900px; }
+.boop-landing .hero h1 .mark { display: block; width: clamp(40px, 7vw, 90px); height: clamp(40px, 7vw, 90px); border-radius: 50%; background: var(--accent); flex-shrink: 0; }
+.boop-landing .hero-signin { margin-top: 20px; font-size: 14px; color: var(--muted); }
+.boop-landing .hero-signin a { color: var(--accent); font-weight: 600; }
+.boop-landing .hero-signin a:hover { text-decoration: underline; }
+.boop-landing .hero-sub { font-size: clamp(17px, 2.1vw, 22px); color: var(--muted); max-width: 620px; line-height: 1.45; margin-bottom: 34px; text-wrap: pretty; }
+.boop-landing .hero-cta { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+.boop-landing .hero-cta .btn-primary { padding: 14px 24px; font-size: 15px; }
+.boop-landing .hero-cta .btn-ghost { padding: 14px 20px; font-size: 15px; }
+.boop-landing .hero-meta { margin-top: 28px; display: inline-flex; align-items: center; gap: 14px; color: var(--muted); font-size: 13px; font-family: var(--mono); }
+.boop-landing .hero-meta .pip { width: 6px; height: 6px; border-radius: 50%; background: var(--ok); }
+
+.boop-landing .shot { margin-top: 56px; position: relative; padding: 40px; background: var(--panel); border-radius: 28px; border: 1px solid var(--line); overflow: hidden; }
+.boop-landing .shot::before { content: ""; position: absolute; top: -80px; right: -100px; width: 340px; height: 340px; border-radius: 50%; background: radial-gradient(circle at center, rgba(107,60,255,0.2), transparent 70%); filter: blur(20px); }
+.boop-landing .shot-grid { display: grid; grid-template-columns: 340px 1fr; gap: 24px; align-items: stretch; position: relative; }
+@media (max-width: 880px) { .boop-landing .shot-grid { grid-template-columns: 1fr; } }
+
+.boop-landing .mock { background: var(--card); border: 1px solid var(--line); border-radius: 20px; padding: 22px; box-shadow: 0 30px 80px rgba(20,10,50,0.1); }
+.boop-landing .mock h3 { margin: 0; font-family: var(--rounded); font-weight: 700; font-size: 22px; letter-spacing: -0.4px; }
+.boop-landing .mock-head { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 18px; }
+.boop-landing .mock-tag { font-size: 11px; color: var(--muted); font-family: var(--mono); margin-bottom: 4px; }
+.boop-landing .avatars { display: flex; }
+.boop-landing .avy { width: 28px; height: 28px; border-radius: 50%; color: #fff; font-family: var(--rounded); font-weight: 800; font-size: 12px; display: inline-flex; align-items: center; justify-content: center; border: 2px solid var(--card); }
+.boop-landing .avy + .avy { margin-left: -10px; }
+.boop-landing .avy-violet { background: var(--accent); }
+.boop-landing .avy-coral { background: #ff6e4a; }
+.boop-landing .avy-green { background: #1a7a4c; }
+.boop-landing .avy.big { width: 40px; height: 40px; font-size: 15px; border: none; }
+
+.boop-landing .item { display: flex; align-items: center; gap: 12px; padding: 11px 0; border-bottom: 1px solid var(--lineSoft); }
+.boop-landing .item:last-child { border-bottom: none; }
+.boop-landing .box { width: 20px; height: 20px; border: 1.6px solid var(--dim); border-radius: 999px; display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; }
+.boop-landing .box.on { background: var(--accent); border-color: var(--accent); }
+.boop-landing .box.on::after { content: ""; width: 10px; height: 6px; border-left: 2px solid #fff; border-bottom: 2px solid #fff; transform: rotate(-45deg) translate(1px, -1px); }
+.boop-landing .item .t { flex: 1; font-size: 14px; }
+.boop-landing .item.done .t { text-decoration: line-through; color: var(--muted); }
+.boop-landing .chip { font-size: 11px; font-family: var(--mono); background: var(--panel); color: var(--muted); padding: 2px 8px; border-radius: 999px; }
+.boop-landing .chip-accent { color: var(--accent); background: var(--accentSoft); }
+
+.boop-landing .section { padding: 80px 0; }
+.boop-landing .section-tight { padding-top: 20px; }
+.boop-landing .section-label { font-family: var(--mono); font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 2px; margin-bottom: 14px; display: inline-flex; align-items: center; gap: 8px; }
+.boop-landing .section-label::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+.boop-landing .section-label-dark { color: rgba(255,255,255,0.6); }
+.boop-landing .section h2 { font-family: var(--rounded); font-weight: 800; font-size: clamp(36px, 5vw, 60px); letter-spacing: -1.8px; line-height: 1.02; margin: 0 0 20px; max-width: 780px; text-wrap: balance; }
+.boop-landing .section h2 em { font-style: normal; color: var(--accent); }
+.boop-landing .section-lede { font-size: 18px; color: var(--muted); max-width: 620px; line-height: 1.5; margin-bottom: 48px; text-wrap: pretty; }
+
+.boop-landing .features { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+@media (max-width: 900px) { .boop-landing .features { grid-template-columns: 1fr; } }
+.boop-landing .feat { background: var(--card); border: 1px solid var(--line); border-radius: 20px; padding: 26px; transition: transform 180ms, box-shadow 180ms; }
+.boop-landing .feat:hover { transform: translateY(-2px); box-shadow: 0 20px 50px rgba(20,10,50,0.08); }
+.boop-landing .feat-icon { width: 44px; height: 44px; border-radius: 12px; background: var(--accentSoft); display: inline-flex; align-items: center; justify-content: center; color: var(--accent); margin-bottom: 18px; }
+.boop-landing .feat h3 { margin: 0 0 8px; font-family: var(--rounded); font-weight: 700; font-size: 19px; letter-spacing: -0.3px; }
+.boop-landing .feat p { margin: 0; font-size: 14px; color: var(--muted); line-height: 1.55; }
+
+.boop-landing .trust { background: #0c0b10; color: #f1eef9; border-radius: 28px; padding: 60px 48px; position: relative; overflow: hidden; margin: 40px 0; }
+.boop-landing .trust::before { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 80% 20%, rgba(107,60,255,0.28), transparent 55%); }
+.boop-landing .trust-grid { display: grid; grid-template-columns: 1.2fr 1fr; gap: 60px; align-items: center; position: relative; }
+@media (max-width: 880px) { .boop-landing .trust-grid { grid-template-columns: 1fr; gap: 40px; } .boop-landing .trust { padding: 48px 28px; } }
+.boop-landing .trust h2 { color: #fff; font-family: var(--rounded); font-weight: 800; font-size: clamp(32px, 4.5vw, 52px); letter-spacing: -1.5px; line-height: 1.05; margin: 0 0 16px; }
+.boop-landing .trust p { font-size: 16px; color: rgba(241,238,249,0.7); line-height: 1.55; margin: 0 0 20px; max-width: 500px; }
+.boop-landing .badge-card { background: rgba(255,255,255,0.05); backdrop-filter: blur(20px); border: 1px solid rgba(255,255,255,0.1); border-radius: 20px; padding: 28px; }
+.boop-landing .badge-card .who { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; }
+.boop-landing .badge-card .name { font-weight: 600; font-size: 15px; display: flex; align-items: center; gap: 6px; color: #fff; }
+.boop-landing .badge-card .did { font-family: var(--mono); font-size: 11px; color: rgba(241,238,249,0.5); }
+.boop-landing .badge-note { font-size: 14px; color: rgba(241,238,249,0.8); margin-bottom: 18px; line-height: 1.5; }
+.boop-landing .signed { display: inline-flex; align-items: center; gap: 8px; font-size: 12px; font-family: var(--mono); color: #6bff9a; padding: 6px 10px; background: rgba(107,255,154,0.1); border-radius: 999px; }
+.boop-landing .signed-dot { width: 6px; height: 6px; border-radius: 50%; background: #6bff9a; }
+
+.boop-landing .pullquote { padding: 100px 0; text-align: center; }
+.boop-landing .pullquote blockquote { font-family: var(--rounded); font-weight: 600; font-size: clamp(28px, 4vw, 44px); letter-spacing: -1.2px; line-height: 1.2; margin: 0 auto; max-width: 840px; text-wrap: balance; color: var(--ink); }
+.boop-landing .pullquote cite { display: block; font-style: normal; font-size: 14px; color: var(--muted); font-family: var(--mono); margin-top: 28px; }
+
+.boop-landing .plans { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+@media (max-width: 900px) { .boop-landing .plans { grid-template-columns: 1fr; } }
+.boop-landing .plan { background: var(--card); border: 1px solid var(--line); border-radius: 20px; padding: 28px; display: flex; flex-direction: column; }
+.boop-landing .plan.hero-plan { background: var(--ink); color: #fff; border: none; }
+.boop-landing .plan.hero-plan .price, .boop-landing .plan.hero-plan .plan-name { color: #fff; }
+.boop-landing .plan-name { font-family: var(--rounded); font-weight: 700; font-size: 20px; margin-bottom: 4px; }
+.boop-landing .plan-desc { font-size: 13px; color: var(--muted); margin-bottom: 24px; }
+.boop-landing .plan.hero-plan .plan-desc { color: rgba(255,255,255,0.6); }
+.boop-landing .price { font-family: var(--rounded); font-weight: 800; font-size: 44px; letter-spacing: -1.5px; line-height: 1; }
+.boop-landing .price small { font-size: 14px; color: var(--muted); font-weight: 500; margin-left: 4px; }
+.boop-landing .plan.hero-plan .price small { color: rgba(255,255,255,0.6); }
+.boop-landing .plan ul { list-style: none; padding: 0; margin: 24px 0; flex: 1; }
+.boop-landing .plan li { font-size: 14px; padding: 8px 0; display: flex; gap: 10px; align-items: flex-start; color: var(--ink); }
+.boop-landing .plan.hero-plan li { color: rgba(255,255,255,0.85); }
+.boop-landing .plan li::before { content: ""; width: 14px; height: 14px; border-radius: 50%; background: var(--accentSoft); flex-shrink: 0; margin-top: 3px; background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M3 6.5l2 2 4.5-5' stroke='%236b3cff' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round' fill='none'/></svg>"); background-position: center; background-repeat: no-repeat; }
+.boop-landing .plan.hero-plan li::before { background-color: rgba(107,60,255,0.3); background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M3 6.5l2 2 4.5-5' stroke='white' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round' fill='none'/></svg>"); }
+.boop-landing .plan-cta { text-align: center; width: 100%; }
+.boop-landing .plan-cta-invert { background: #fff; color: var(--accent); }
+.boop-landing .plan-cta-invert:hover { background: #f1eef9; }
+
+.boop-landing .cta-wrap { padding: 60px 0; }
+.boop-landing .cta-band { background: var(--accent); color: #fff; border-radius: 28px; padding: 80px 40px; text-align: center; position: relative; overflow: hidden; }
+.boop-landing .cta-band::before { content: ""; position: absolute; top: -100px; left: -100px; width: 300px; height: 300px; border-radius: 50%; background: rgba(255,255,255,0.1); }
+.boop-landing .cta-band::after { content: ""; position: absolute; bottom: -120px; right: -80px; width: 400px; height: 400px; border-radius: 50%; background: rgba(255,255,255,0.08); }
+.boop-landing .cta-band h2 { position: relative; font-family: var(--rounded); font-weight: 900; font-size: clamp(36px, 6vw, 68px); letter-spacing: -2px; line-height: 1; margin: 0 0 20px; color: #fff; }
+.boop-landing .cta-band p { position: relative; font-size: 18px; opacity: 0.88; margin: 0 0 32px; }
+.boop-landing .cta-btn { background: #fff; color: var(--accent); padding: 16px 28px; font-size: 16px; position: relative; }
+.boop-landing .cta-btn:hover { background: #f1eef9; }
+
+.boop-landing footer { padding: 60px 0 80px; border-top: 1px solid var(--lineSoft); }
+.boop-landing .foot { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 32px; }
+.boop-landing .foot-col { display: flex; flex-direction: column; gap: 10px; font-size: 14px; color: var(--muted); }
+.boop-landing .foot-col-brand { max-width: 280px; }
+.boop-landing .foot-col strong { color: var(--ink); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 1.2px; font-family: var(--mono); margin-bottom: 6px; }
+.boop-landing .foot-col a:hover { color: var(--ink); }
+.boop-landing .foot-tag { font-size: 13px; }
+.boop-landing .foot-bottom { margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--lineSoft); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; font-size: 12px; color: var(--dim); font-family: var(--mono); }
+
+.boop-landing .phone { width: 300px; margin: 0 auto; background: var(--ink); border-radius: 44px; padding: 10px; box-shadow: 0 40px 80px rgba(20,10,50,0.2); position: relative; }
+.boop-landing .phone-inner { background: var(--bg); border-radius: 34px; overflow: hidden; aspect-ratio: 9 / 19.5; padding: 22px 18px; }
+.boop-landing .phone-topbar { display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: var(--muted); font-family: var(--mono); margin-bottom: 18px; }
+.boop-landing .phone h4 { margin: 14px 0 4px; font-family: var(--rounded); font-weight: 700; font-size: 22px; letter-spacing: -0.4px; }
+.boop-landing .mono-sub { font-size: 12px; color: var(--muted); font-family: var(--mono); }
+.boop-landing .progress { height: 4px; background: var(--line); border-radius: 999px; overflow: hidden; margin: 14px 0 18px; }
+.boop-landing .progress > div { height: 100%; width: 62%; background: var(--accent); border-radius: 999px; }
+.boop-landing .progress-lg { height: 6px; margin-bottom: 20px; }
+
+.boop-landing .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px; margin: 40px 0; }
+@media (max-width: 760px) { .boop-landing .stats { grid-template-columns: repeat(2, 1fr); } }
+.boop-landing .stat { padding: 24px; background: var(--card); border: 1px solid var(--line); border-radius: 18px; }
+.boop-landing .stat .n { font-family: var(--rounded); font-weight: 800; font-size: 36px; letter-spacing: -1px; }
+.boop-landing .stat .l { font-size: 13px; color: var(--muted); margin-top: 2px; }
+
+.boop-landing .faq-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px 48px; margin-top: 40px; }
+@media (max-width: 760px) { .boop-landing .faq-grid { grid-template-columns: 1fr; } }
+.boop-landing .faq-q { font-family: var(--rounded); font-weight: 700; font-size: 17px; margin: 0 0 8px; }
+.boop-landing .faq-a { font-size: 14px; color: var(--muted); line-height: 1.6; margin: 0; }

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,11 +1,6 @@
 /**
- * Landing page for Poo App
- * "Organize your life while you Poop"
- *
- * Responsive design with mobile-first approach:
- * - Mobile: < 640px (sm)
- * - Tablet: 640px - 1024px (md)
- * - Desktop: > 1024px (lg)
+ * Boop marketing landing page.
+ * Ported from design handoff: Boop Landing.html.
  */
 
 import { Link } from 'react-router-dom';
@@ -13,131 +8,502 @@ import { useAuth } from '../hooks/useAuth';
 
 export function Landing() {
   const { isAuthenticated } = useAuth();
+  const appHref = isAuthenticated ? '/' : '/login';
 
   return (
-    <div className="min-h-screen bg-amber-50 overflow-x-hidden">
+    <div className="boop-landing">
+      <style>{boopStyles}</style>
 
-      {/* Header */}
-      <header className="pt-14 px-4 pb-4 sm:pt-8 sm:px-6 sm:pb-6 safe-area-inset-top">
-        <nav className="max-w-4xl mx-auto flex items-center justify-between gap-4">
-          <div className="flex items-center gap-1.5 sm:gap-2 min-w-0">
-            <span className="text-2xl sm:text-3xl flex-shrink-0">💩</span>
-            <span className="font-black text-lg sm:text-xl text-amber-900 truncate">Poo App</span>
+      <nav className="nav">
+        <div className="wrap nav-inner">
+          <a href="#" className="wordmark"><span className="dot" />boop</a>
+          <div className="nav-links">
+            <a href="#how">How it works</a>
+            <a href="#trust">Trust</a>
+            <a href="#pricing">Pricing</a>
+            <a href="#faq">FAQ</a>
           </div>
-          <Link
-            to={isAuthenticated ? '/' : '/login'}
-            className="px-4 sm:px-6 py-2 sm:py-2.5 bg-amber-900 text-amber-50 rounded-full font-semibold text-sm sm:text-base hover:bg-amber-800 active:bg-amber-950 transition-colors whitespace-nowrap flex-shrink-0"
-          >
-            {isAuthenticated ? 'Open App' : 'Sign In'}
-          </Link>
-        </nav>
-      </header>
-
-      {/* Hero */}
-      <main className="max-w-4xl mx-auto px-4 sm:px-6 pt-12 sm:pt-20 md:pt-28 pb-16 sm:pb-20 md:pb-24">
-        <div className="text-center">
-          <div className="text-[72px] sm:text-[96px] md:text-[112px] leading-none mb-6 sm:mb-8 cursor-default select-none hover:animate-wiggle" aria-hidden="true">
-            💩
+          <div className="nav-cta">
+            <Link to={appHref} className="btn btn-ghost">Sign in</Link>
+            <Link to={appHref} className="btn btn-primary">Get boop</Link>
           </div>
-
-          <h1 className="text-4xl sm:text-5xl md:text-6xl lg:text-8xl font-black text-amber-900 mb-6 sm:mb-8 leading-[0.95] tracking-tight">
-            Organize your life
-            <br />
-            <span className="font-light text-amber-700">while you</span> Poop
-          </h1>
-
-          <p className="text-base sm:text-lg md:text-xl text-amber-800/60 max-w-md mx-auto mb-10 sm:mb-14 leading-relaxed">
-            The world's most <em>productive</em> todo app. Turn your bathroom breaks
-            into breakthrough moments.
-          </p>
-
-          <Link
-            to={isAuthenticated ? '/app?action=new' : '/login'}
-            className="inline-flex px-10 py-4 bg-amber-900 text-amber-50 rounded-full font-bold text-base sm:text-lg hover:bg-amber-800 active:bg-amber-950 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 focus:ring-offset-amber-50 transition-colors min-h-[52px] items-center justify-center"
-          >
-            {isAuthenticated ? 'Start a List' : 'Sign in to Start a List'}
-          </Link>
         </div>
+      </nav>
 
-        {/* Features */}
-        <section id="features" className="mt-28 sm:mt-36 md:mt-44 scroll-mt-16 sm:scroll-mt-20">
-
-          {/* Lead feature — the differentiator */}
-          <div className="bg-amber-900 text-amber-50 rounded-2xl p-8 sm:p-10 md:p-12 mb-4 sm:mb-6">
-            <div className="max-w-lg">
-              <div className="text-3xl mb-4">🔐</div>
-              <h3 className="text-xl sm:text-2xl md:text-3xl font-bold mb-3 leading-snug">
-                Cryptographically yours
-              </h3>
-              <p className="text-amber-200 text-sm sm:text-base md:text-lg leading-relaxed">
-                Every task is signed with your personal keys via the Originals Protocol.
-                Your todos, your proof, your legacy — not someone else's database entry.
-              </p>
-            </div>
-          </div>
-
-          {/* Supporting features */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
-            <div className="bg-white rounded-2xl p-6 sm:p-8 border border-amber-100">
-              <div className="text-2xl sm:text-3xl mb-3">⚡</div>
-              <h3 className="text-lg font-bold text-amber-900 mb-1.5">Lightning fast</h3>
-              <p className="text-sm text-amber-800/60 leading-relaxed">
-                Add tasks faster than... well, you know. Perfect for those quick sessions.
-              </p>
-            </div>
-
-            <div className="bg-white rounded-2xl p-6 sm:p-8 border border-amber-100">
-              <div className="text-2xl sm:text-3xl mb-3">👥</div>
-              <h3 className="text-lg font-bold text-amber-900 mb-1.5">Share lists</h3>
-              <p className="text-sm text-amber-800/60 leading-relaxed">
-                Collaborate with family, roommates, or coworkers. Shared accountability, shared relief.
-              </p>
-            </div>
-          </div>
-        </section>
-
-        {/* Bottom CTA */}
-        <section className="mt-28 sm:mt-36 md:mt-44 text-center">
-          <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-amber-900 mb-3 sm:mb-4">
-            Ready to be more productive?
-          </h2>
-          <p className="text-sm sm:text-base md:text-lg text-amber-800/60 mb-8 sm:mb-10 max-w-md mx-auto">
-            Join thousands who've transformed their bathroom time into
-            the most organized part of their day.
+      <section className="hero">
+        <div className="wrap">
+          <h1><span className="mark" />boop.</h1>
+          <p className="hero-sub">
+            A calm little place for the things you need to do — alone or with a few people you trust.
+            No feeds, no nags, no notifications asking how you feel.
           </p>
-          <Link
-            to={isAuthenticated ? '/' : '/login'}
-            className="inline-flex px-10 py-4 sm:py-5 bg-amber-900 text-amber-50 rounded-full font-bold text-lg sm:text-xl hover:bg-amber-800 active:bg-amber-950 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-2 focus:ring-offset-amber-50 transition-colors min-h-[56px] items-center justify-center"
-          >
-            Start Organizing 💩
-          </Link>
-        </section>
-      </main>
+          <div className="hero-cta">
+            <Link to={appHref} className="btn btn-primary">Get boop — free</Link>
+            <a href="#how" className="btn btn-ghost">See how it works →</a>
+          </div>
+          <div className="hero-meta">
+            <span className="pip" />
+            <span>no ads · no tracking · end-to-end signed</span>
+          </div>
 
-      {/* Footer */}
-      <footer className="border-t border-amber-200 bg-amber-50 py-8 sm:py-10 safe-area-inset-bottom">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 text-center text-amber-700/60 text-xs sm:text-sm">
-          <p>Made with 💩 by Aviary Tech</p>
-          <p className="mt-2">Powered by Originals Protocol</p>
+          <div className="shot">
+            <div className="shot-grid">
+              <div className="phone">
+                <div className="phone-inner">
+                  <div className="phone-topbar">
+                    <span>9:41</span>
+                    <span>•••</span>
+                  </div>
+                  <div className="wordmark wordmark-sm"><span className="dot" />boop</div>
+                  <h4>Weekend, again.</h4>
+                  <div className="mono-sub">shared · with jamie</div>
+                  <div className="progress"><div /></div>
+
+                  <div className="item"><span className="box on" /><span className="t">Call mom</span></div>
+                  <div className="item"><span className="box" /><span className="t">Long walk, no phone</span></div>
+                  <div className="item"><span className="box" /><span className="t">Finish the book</span><span className="chip">!! high</span></div>
+                  <div className="item"><span className="box on" /><span className="t">Tomatoes, a lot</span><span className="chip">produce</span></div>
+                  <div className="item"><span className="box" /><span className="t">Basil</span><span className="chip">produce</span></div>
+                </div>
+              </div>
+              <div className="mock">
+                <div className="mock-head">
+                  <div>
+                    <div className="mock-tag">shared</div>
+                    <h3>Sprint 24</h3>
+                  </div>
+                  <div className="avatars">
+                    <div className="avy avy-violet">R</div>
+                    <div className="avy avy-coral">J</div>
+                    <div className="avy avy-green">M</div>
+                  </div>
+                </div>
+                <div className="progress progress-lg"><div /></div>
+                <div className="item done"><span className="box on" /><span className="t">Finalize auth migration plan</span><span className="chip">eng</span></div>
+                <div className="item done"><span className="box on" /><span className="t">Review PR #2317</span><span className="chip">review</span></div>
+                <div className="item done"><span className="box on" /><span className="t">Write launch post</span><span className="chip">comms</span></div>
+                <div className="item"><span className="box" /><span className="t">Perf investigation</span><span className="chip chip-accent">!! high</span></div>
+                <div className="item"><span className="box" /><span className="t">Ship settings redesign</span><span className="chip">eng</span></div>
+                <div className="item"><span className="box" /><span className="t">Customer sync — Acme</span><span className="chip">cs</span></div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section" id="how">
+        <div className="wrap">
+          <div className="section-label">how it works</div>
+          <h2>Three things,<br />done <em>beautifully</em>.</h2>
+          <p className="section-lede">
+            No second-brain claims. No AI that rewrites your life. Just a fast, quiet way to remember stuff and check it off.
+          </p>
+
+          <div className="features">
+            <div className="feat">
+              <div className="feat-icon">
+                <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+                  <rect x="3" y="3" width="14" height="14" rx="3" stroke="currentColor" strokeWidth="1.6" />
+                  <path d="M7 10l2 2 4-5" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                </svg>
+              </div>
+              <h3>Write it down.</h3>
+              <p>Open boop. Type. Hit return. You can add <kbd>#tags</kbd> and <kbd>!!</kbd> priorities inline. That's it — that's the app.</p>
+            </div>
+            <div className="feat">
+              <div className="feat-icon">
+                <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+                  <circle cx="5" cy="5" r="2.5" stroke="currentColor" strokeWidth="1.6" />
+                  <circle cx="15" cy="10" r="2.5" stroke="currentColor" strokeWidth="1.6" />
+                  <circle cx="5" cy="15" r="2.5" stroke="currentColor" strokeWidth="1.6" />
+                  <path d="M7 6l6 3M7 14l6-3" stroke="currentColor" strokeWidth="1.6" />
+                </svg>
+              </div>
+              <h3>Share, carefully.</h3>
+              <p>Invite a few humans. Lists carry a signature so collaborators know it really came from you. Not blockchain jargon — a quiet green dot.</p>
+            </div>
+            <div className="feat">
+              <div className="feat-icon">
+                <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+                  <path d="M10 4v6l4 2" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+                  <circle cx="10" cy="10" r="7" stroke="currentColor" strokeWidth="1.6" />
+                </svg>
+              </div>
+              <h3>Boop it.</h3>
+              <p>Check the box. Feel the little pop. Watch the progress ring fill. No social graph, no streak lectures — just the quiet satisfaction of a done thing.</p>
+            </div>
+          </div>
+
+          <div className="stats">
+            <div className="stat"><div className="n">3s</div><div className="l">to capture a thing</div></div>
+            <div className="stat"><div className="n">0</div><div className="l">notifications unless you ask</div></div>
+            <div className="stat"><div className="n">⌘K</div><div className="l">to go anywhere</div></div>
+            <div className="stat"><div className="n">E2EE</div><div className="l">on shared lists, by default</div></div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section section-tight" id="trust">
+        <div className="wrap">
+          <div className="trust">
+            <div className="trust-grid">
+              <div>
+                <div className="section-label section-label-dark">trust, not hype</div>
+                <h2>Your lists are yours.<br />Proven, not promised.</h2>
+                <p>
+                  Every list you share carries a signature from your device. Collaborators see a verified badge —
+                  so nobody can spoof "Mom's grocery list" or edit your sprint plan without leaving a trace.
+                </p>
+                <p>
+                  You can export your key, rotate it, or switch devices. The usual web3 strangeness stays behind the curtain.
+                  You just see a small green dot.
+                </p>
+              </div>
+              <div className="badge-card">
+                <div className="who">
+                  <span className="avy avy-violet big">R</span>
+                  <div>
+                    <div className="name">
+                      Riley Chen
+                      <svg width="14" height="14" viewBox="0 0 12 12" fill="none">
+                        <path d="M6 1l1.5 1.2 1.8-.1.2 1.8L10.8 5 10 6.5l.8 1.5-1.3 1.1-.2 1.8-1.8-.1L6 11l-1.5-1.2-1.8.1-.2-1.8L1.2 7 2 5.5 1.2 4l1.3-1.1.2-1.8 1.8.1L6 1z" fill="#6b3cff" />
+                        <path d="M4 6l1.5 1.5L8 4.5" stroke="#fff" strokeWidth="1.3" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </div>
+                    <div className="did">did:boop:rly.2kx8f…9qn</div>
+                  </div>
+                </div>
+                <div className="badge-note">
+                  "Sprint 24" shared this list with 3 people. Signed 2 minutes ago.
+                </div>
+                <span className="signed">
+                  <span className="signed-dot" />
+                  verified · signature intact
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="pullquote">
+        <div className="wrap">
+          <blockquote>
+            "Finally, a to-do app that doesn't want to be my second brain, my coach, or my life partner. It just remembers milk."
+          </blockquote>
+          <cite>— every early tester, basically</cite>
+        </div>
+      </section>
+
+      <section className="section" id="pricing">
+        <div className="wrap">
+          <div className="section-label">pricing</div>
+          <h2>Fair, flat, forever.</h2>
+          <p className="section-lede">One paid tier, priced for a human. Free forever for solo use. No per-seat price-gouging.</p>
+
+          <div className="plans">
+            <div className="plan">
+              <div className="plan-name">Personal</div>
+              <div className="plan-desc">For you and your groceries.</div>
+              <div className="price">$0<small>/forever</small></div>
+              <ul>
+                <li>Unlimited personal lists</li>
+                <li>Calendar view</li>
+                <li>Keyboard shortcuts, ⌘K palette</li>
+                <li>Light + dark</li>
+              </ul>
+              <Link to={appHref} className="btn btn-ghost plan-cta">Start free</Link>
+            </div>
+            <div className="plan hero-plan">
+              <div className="plan-name">Shared</div>
+              <div className="plan-desc">For a few humans you trust.</div>
+              <div className="price">$5<small>/month</small></div>
+              <ul>
+                <li>Everything in Personal</li>
+                <li>Shared + signed lists</li>
+                <li>Up to 8 collaborators per list</li>
+                <li>Activity history</li>
+                <li>Identity + verification</li>
+              </ul>
+              <Link to={appHref} className="btn btn-primary plan-cta plan-cta-invert">Start 14-day trial</Link>
+            </div>
+            <div className="plan">
+              <div className="plan-name">Team</div>
+              <div className="plan-desc">For small teams, no nonsense.</div>
+              <div className="price">$8<small>/user/month</small></div>
+              <ul>
+                <li>Everything in Shared</li>
+                <li>Unlimited collaborators</li>
+                <li>Workspace templates</li>
+                <li>SSO, audit log</li>
+                <li>Priority support</li>
+              </ul>
+              <a href="mailto:hello@boop.app" className="btn btn-ghost plan-cta">Contact us</a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="section section-tight" id="faq">
+        <div className="wrap">
+          <div className="section-label">faq</div>
+          <h2>Just the honest questions.</h2>
+
+          <div className="faq-grid">
+            <div>
+              <h3 className="faq-q">Is this another second-brain app?</h3>
+              <p className="faq-a">No. It's a first-brain app. It remembers the five things you need to do today and gets out of the way.</p>
+            </div>
+            <div>
+              <h3 className="faq-q">Do I need to understand DIDs?</h3>
+              <p className="faq-a">No. You'll see a small green dot next to your name. That's the whole user-facing surface.</p>
+            </div>
+            <div>
+              <h3 className="faq-q">Offline?</h3>
+              <p className="faq-a">Works fully offline. Syncs when you reconnect. Your device holds your signing key.</p>
+            </div>
+            <div>
+              <h3 className="faq-q">Do you sell my data?</h3>
+              <p className="faq-a">We can't. Shared lists are end-to-end encrypted. We see a blob of ciphertext and the bill you pay us. That's how it should be.</p>
+            </div>
+            <div>
+              <h3 className="faq-q">Will you add AI?</h3>
+              <p className="faq-a">Only if it helps you write down "milk" faster. Probably not.</p>
+            </div>
+            <div>
+              <h3 className="faq-q">What platforms?</h3>
+              <p className="faq-a">iOS, Android, Mac, Windows, web. Keyboard-first on desktop. Thumb-first on mobile.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="cta-wrap">
+        <div className="wrap">
+          <div className="cta-band">
+            <h2>One thing, then<br />the next.</h2>
+            <p>Free for solo use. Nothing to cancel.</p>
+            <Link to={appHref} className="btn btn-primary cta-btn">Get boop</Link>
+          </div>
+        </div>
+      </section>
+
+      <footer>
+        <div className="wrap">
+          <div className="foot">
+            <div className="foot-col foot-col-brand">
+              <div className="wordmark wordmark-sm"><span className="dot" />boop</div>
+              <div className="foot-tag">Made carefully, in a quiet room.</div>
+            </div>
+            <div className="foot-col">
+              <strong>Product</strong>
+              <a href="#how">How it works</a>
+              <a href="#pricing">Pricing</a>
+              <a href="#">Changelog</a>
+              <a href="#">Roadmap</a>
+            </div>
+            <div className="foot-col">
+              <strong>Trust</strong>
+              <Link to="/privacy">Privacy</Link>
+              <a href="#trust">Security</a>
+              <a href="#">Open protocol</a>
+              <a href="#">Delete my data</a>
+            </div>
+            <div className="foot-col">
+              <strong>Company</strong>
+              <a href="#">About</a>
+              <a href="#">Manifesto</a>
+              <a href="mailto:hello@boop.app">Contact</a>
+            </div>
+          </div>
+          <div className="foot-bottom">
+            <span>© 2026 boop · made in a quiet room</span>
+            <span>v0.4.0 · signed build</span>
+          </div>
         </div>
       </footer>
-      <style>{`
-        @keyframes wiggle {
-          0%, 100% { transform: rotate(0deg); }
-          20% { transform: rotate(-6deg); }
-          40% { transform: rotate(5deg); }
-          60% { transform: rotate(-3deg); }
-          80% { transform: rotate(2deg); }
-        }
-        .hover\\:animate-wiggle:hover {
-          animation: wiggle 0.5s ease-in-out;
-        }
-        @media (prefers-reduced-motion: reduce) {
-          .hover\\:animate-wiggle:hover {
-            animation: none;
-          }
-        }
-      `}</style>
     </div>
   );
 }
+
+const boopStyles = `
+  @import url('https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&family=Nunito:wght@500;600;700;800;900&display=swap');
+
+  .boop-landing {
+    --bg: #fafaf7;
+    --card: #ffffff;
+    --panel: #f4f3ee;
+    --ink: #111014;
+    --muted: #6b6a74;
+    --dim: #a8a7b0;
+    --line: #ecebe6;
+    --lineSoft: #f3f2ec;
+    --accent: #6b3cff;
+    --accentSoft: #ece4ff;
+    --accentInk: #2a1570;
+    --ok: #1a7a4c;
+    --sans: 'Geist', 'Inter', system-ui, sans-serif;
+    --rounded: 'Nunito', system-ui, sans-serif;
+    --mono: 'Geist Mono', ui-monospace, monospace;
+
+    background: var(--bg);
+    color: var(--ink);
+    font-family: var(--sans);
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+    min-height: 100vh;
+  }
+  .boop-landing * { box-sizing: border-box; }
+  .boop-landing button { font: inherit; cursor: pointer; }
+  .boop-landing a { color: inherit; text-decoration: none; }
+  .boop-landing kbd { font-family: var(--mono); font-size: 0.85em; background: var(--panel); border: 1px solid var(--line); padding: 1px 6px; border-radius: 4px; }
+
+  .boop-landing .wrap { max-width: 1180px; margin: 0 auto; padding: 0 32px; }
+  @media (max-width: 720px) { .boop-landing .wrap { padding: 0 20px; } }
+
+  .boop-landing .nav { position: sticky; top: 0; z-index: 20; backdrop-filter: blur(14px); background: rgba(250,250,247,0.75); border-bottom: 1px solid var(--lineSoft); }
+  .boop-landing .nav-inner { display: flex; align-items: center; justify-content: space-between; height: 64px; }
+  .boop-landing .wordmark { display: inline-flex; align-items: center; gap: 8px; font-family: var(--rounded); font-weight: 800; font-size: 22px; letter-spacing: -0.8px; color: var(--ink); }
+  .boop-landing .wordmark .dot { width: 16px; height: 16px; border-radius: 50%; background: var(--accent); }
+  .boop-landing .wordmark-sm { font-size: 18px; gap: 6px; }
+  .boop-landing .wordmark-sm .dot { width: 13px; height: 13px; }
+  .boop-landing .nav-links { display: flex; gap: 28px; font-size: 14px; color: var(--muted); }
+  .boop-landing .nav-links a:hover { color: var(--ink); }
+  .boop-landing .nav-cta { display: flex; gap: 10px; align-items: center; }
+  .boop-landing .btn { border: none; border-radius: 999px; padding: 10px 18px; font-size: 14px; font-weight: 600; font-family: var(--sans); white-space: nowrap; transition: transform 120ms, box-shadow 120ms, background 120ms; display: inline-flex; align-items: center; justify-content: center; }
+  .boop-landing .btn-primary { background: var(--accent); color: #fff; box-shadow: 0 6px 18px rgba(107,60,255,0.3); }
+  .boop-landing .btn-primary:hover { transform: translateY(-1px); box-shadow: 0 10px 24px rgba(107,60,255,0.38); }
+  .boop-landing .btn-ghost { background: transparent; color: var(--ink); border: 1px solid var(--line); }
+  .boop-landing .btn-ghost:hover { background: var(--panel); }
+  @media (max-width: 820px) { .boop-landing .nav-links { display: none; } }
+
+  .boop-landing .hero { padding: 80px 0 60px; position: relative; }
+  .boop-landing .hero h1 { font-family: var(--rounded); font-weight: 900; font-size: clamp(48px, 8vw, 108px); letter-spacing: -3px; line-height: 0.95; margin: 0 0 24px; max-width: 900px; text-wrap: balance; }
+  .boop-landing .hero h1 .mark { display: inline-block; width: clamp(40px, 7vw, 90px); height: clamp(40px, 7vw, 90px); border-radius: 50%; background: var(--accent); vertical-align: -0.14em; margin-right: 14px; }
+  .boop-landing .hero-sub { font-size: clamp(17px, 2.1vw, 22px); color: var(--muted); max-width: 620px; line-height: 1.45; margin-bottom: 34px; text-wrap: pretty; }
+  .boop-landing .hero-cta { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+  .boop-landing .hero-cta .btn-primary { padding: 14px 24px; font-size: 15px; }
+  .boop-landing .hero-cta .btn-ghost { padding: 14px 20px; font-size: 15px; }
+  .boop-landing .hero-meta { margin-top: 28px; display: inline-flex; align-items: center; gap: 14px; color: var(--muted); font-size: 13px; font-family: var(--mono); }
+  .boop-landing .hero-meta .pip { width: 6px; height: 6px; border-radius: 50%; background: var(--ok); }
+
+  .boop-landing .shot { margin-top: 56px; position: relative; padding: 40px; background: var(--panel); border-radius: 28px; border: 1px solid var(--line); overflow: hidden; }
+  .boop-landing .shot::before { content: ""; position: absolute; top: -80px; right: -100px; width: 340px; height: 340px; border-radius: 50%; background: radial-gradient(circle at center, rgba(107,60,255,0.2), transparent 70%); filter: blur(20px); }
+  .boop-landing .shot-grid { display: grid; grid-template-columns: 340px 1fr; gap: 24px; align-items: stretch; position: relative; }
+  @media (max-width: 880px) { .boop-landing .shot-grid { grid-template-columns: 1fr; } }
+
+  .boop-landing .mock { background: var(--card); border: 1px solid var(--line); border-radius: 20px; padding: 22px; box-shadow: 0 30px 80px rgba(20,10,50,0.1); }
+  .boop-landing .mock h3 { margin: 0; font-family: var(--rounded); font-weight: 700; font-size: 22px; letter-spacing: -0.4px; }
+  .boop-landing .mock-head { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 18px; }
+  .boop-landing .mock-tag { font-size: 11px; color: var(--muted); font-family: var(--mono); margin-bottom: 4px; }
+  .boop-landing .avatars { display: flex; }
+  .boop-landing .avy { width: 28px; height: 28px; border-radius: 50%; color: #fff; font-family: var(--rounded); font-weight: 800; font-size: 12px; display: inline-flex; align-items: center; justify-content: center; border: 2px solid var(--card); }
+  .boop-landing .avy + .avy { margin-left: -10px; }
+  .boop-landing .avy-violet { background: var(--accent); }
+  .boop-landing .avy-coral { background: #ff6e4a; }
+  .boop-landing .avy-green { background: #1a7a4c; }
+  .boop-landing .avy.big { width: 40px; height: 40px; font-size: 15px; border: none; }
+
+  .boop-landing .item { display: flex; align-items: center; gap: 12px; padding: 11px 0; border-bottom: 1px solid var(--lineSoft); }
+  .boop-landing .item:last-child { border-bottom: none; }
+  .boop-landing .box { width: 20px; height: 20px; border: 1.6px solid var(--dim); border-radius: 999px; display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .boop-landing .box.on { background: var(--accent); border-color: var(--accent); }
+  .boop-landing .box.on::after { content: ""; width: 10px; height: 6px; border-left: 2px solid #fff; border-bottom: 2px solid #fff; transform: rotate(-45deg) translate(1px, -1px); }
+  .boop-landing .item .t { flex: 1; font-size: 14px; }
+  .boop-landing .item.done .t { text-decoration: line-through; color: var(--muted); }
+  .boop-landing .chip { font-size: 11px; font-family: var(--mono); background: var(--panel); color: var(--muted); padding: 2px 8px; border-radius: 999px; }
+  .boop-landing .chip-accent { color: var(--accent); background: var(--accentSoft); }
+
+  .boop-landing .section { padding: 80px 0; }
+  .boop-landing .section-tight { padding-top: 20px; }
+  .boop-landing .section-label { font-family: var(--mono); font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 2px; margin-bottom: 14px; display: inline-flex; align-items: center; gap: 8px; }
+  .boop-landing .section-label::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+  .boop-landing .section-label-dark { color: rgba(255,255,255,0.6); }
+  .boop-landing .section h2 { font-family: var(--rounded); font-weight: 800; font-size: clamp(36px, 5vw, 60px); letter-spacing: -1.8px; line-height: 1.02; margin: 0 0 20px; max-width: 780px; text-wrap: balance; }
+  .boop-landing .section h2 em { font-style: normal; color: var(--accent); }
+  .boop-landing .section-lede { font-size: 18px; color: var(--muted); max-width: 620px; line-height: 1.5; margin-bottom: 48px; text-wrap: pretty; }
+
+  .boop-landing .features { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
+  @media (max-width: 900px) { .boop-landing .features { grid-template-columns: 1fr; } }
+  .boop-landing .feat { background: var(--card); border: 1px solid var(--line); border-radius: 20px; padding: 26px; transition: transform 180ms, box-shadow 180ms; }
+  .boop-landing .feat:hover { transform: translateY(-2px); box-shadow: 0 20px 50px rgba(20,10,50,0.08); }
+  .boop-landing .feat-icon { width: 44px; height: 44px; border-radius: 12px; background: var(--accentSoft); display: inline-flex; align-items: center; justify-content: center; color: var(--accent); margin-bottom: 18px; }
+  .boop-landing .feat h3 { margin: 0 0 8px; font-family: var(--rounded); font-weight: 700; font-size: 19px; letter-spacing: -0.3px; }
+  .boop-landing .feat p { margin: 0; font-size: 14px; color: var(--muted); line-height: 1.55; }
+
+  .boop-landing .trust { background: #0c0b10; color: #f1eef9; border-radius: 28px; padding: 60px 48px; position: relative; overflow: hidden; margin: 40px 0; }
+  .boop-landing .trust::before { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 80% 20%, rgba(107,60,255,0.28), transparent 55%); }
+  .boop-landing .trust-grid { display: grid; grid-template-columns: 1.2fr 1fr; gap: 60px; align-items: center; position: relative; }
+  @media (max-width: 880px) { .boop-landing .trust-grid { grid-template-columns: 1fr; gap: 40px; } .boop-landing .trust { padding: 48px 28px; } }
+  .boop-landing .trust h2 { color: #fff; font-family: var(--rounded); font-weight: 800; font-size: clamp(32px, 4.5vw, 52px); letter-spacing: -1.5px; line-height: 1.05; margin: 0 0 16px; }
+  .boop-landing .trust p { font-size: 16px; color: rgba(241,238,249,0.7); line-height: 1.55; margin: 0 0 20px; max-width: 500px; }
+  .boop-landing .badge-card { background: rgba(255,255,255,0.05); backdrop-filter: blur(20px); border: 1px solid rgba(255,255,255,0.1); border-radius: 20px; padding: 28px; }
+  .boop-landing .badge-card .who { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; }
+  .boop-landing .badge-card .name { font-weight: 600; font-size: 15px; display: flex; align-items: center; gap: 6px; color: #fff; }
+  .boop-landing .badge-card .did { font-family: var(--mono); font-size: 11px; color: rgba(241,238,249,0.5); }
+  .boop-landing .badge-note { font-size: 14px; color: rgba(241,238,249,0.8); margin-bottom: 18px; line-height: 1.5; }
+  .boop-landing .signed { display: inline-flex; align-items: center; gap: 8px; font-size: 12px; font-family: var(--mono); color: #6bff9a; padding: 6px 10px; background: rgba(107,255,154,0.1); border-radius: 999px; }
+  .boop-landing .signed-dot { width: 6px; height: 6px; border-radius: 50%; background: #6bff9a; }
+
+  .boop-landing .pullquote { padding: 100px 0; text-align: center; }
+  .boop-landing .pullquote blockquote { font-family: var(--rounded); font-weight: 600; font-size: clamp(28px, 4vw, 44px); letter-spacing: -1.2px; line-height: 1.2; margin: 0 auto; max-width: 840px; text-wrap: balance; color: var(--ink); }
+  .boop-landing .pullquote cite { display: block; font-style: normal; font-size: 14px; color: var(--muted); font-family: var(--mono); margin-top: 28px; }
+
+  .boop-landing .plans { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+  @media (max-width: 900px) { .boop-landing .plans { grid-template-columns: 1fr; } }
+  .boop-landing .plan { background: var(--card); border: 1px solid var(--line); border-radius: 20px; padding: 28px; display: flex; flex-direction: column; }
+  .boop-landing .plan.hero-plan { background: var(--ink); color: #fff; border: none; }
+  .boop-landing .plan.hero-plan .price, .boop-landing .plan.hero-plan .plan-name { color: #fff; }
+  .boop-landing .plan-name { font-family: var(--rounded); font-weight: 700; font-size: 20px; margin-bottom: 4px; }
+  .boop-landing .plan-desc { font-size: 13px; color: var(--muted); margin-bottom: 24px; }
+  .boop-landing .plan.hero-plan .plan-desc { color: rgba(255,255,255,0.6); }
+  .boop-landing .price { font-family: var(--rounded); font-weight: 800; font-size: 44px; letter-spacing: -1.5px; line-height: 1; }
+  .boop-landing .price small { font-size: 14px; color: var(--muted); font-weight: 500; margin-left: 4px; }
+  .boop-landing .plan.hero-plan .price small { color: rgba(255,255,255,0.6); }
+  .boop-landing .plan ul { list-style: none; padding: 0; margin: 24px 0; flex: 1; }
+  .boop-landing .plan li { font-size: 14px; padding: 8px 0; display: flex; gap: 10px; align-items: flex-start; color: var(--ink); }
+  .boop-landing .plan.hero-plan li { color: rgba(255,255,255,0.85); }
+  .boop-landing .plan li::before { content: ""; width: 14px; height: 14px; border-radius: 50%; background: var(--accentSoft); flex-shrink: 0; margin-top: 3px; background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M3 6.5l2 2 4.5-5' stroke='%236b3cff' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round' fill='none'/></svg>"); background-position: center; background-repeat: no-repeat; }
+  .boop-landing .plan.hero-plan li::before { background-color: rgba(107,60,255,0.3); background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M3 6.5l2 2 4.5-5' stroke='white' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round' fill='none'/></svg>"); }
+  .boop-landing .plan-cta { text-align: center; width: 100%; }
+  .boop-landing .plan-cta-invert { background: #fff; color: var(--accent); }
+  .boop-landing .plan-cta-invert:hover { background: #f1eef9; }
+
+  .boop-landing .cta-wrap { padding: 60px 0; }
+  .boop-landing .cta-band { background: var(--accent); color: #fff; border-radius: 28px; padding: 80px 40px; text-align: center; position: relative; overflow: hidden; }
+  .boop-landing .cta-band::before { content: ""; position: absolute; top: -100px; left: -100px; width: 300px; height: 300px; border-radius: 50%; background: rgba(255,255,255,0.1); }
+  .boop-landing .cta-band::after { content: ""; position: absolute; bottom: -120px; right: -80px; width: 400px; height: 400px; border-radius: 50%; background: rgba(255,255,255,0.08); }
+  .boop-landing .cta-band h2 { position: relative; font-family: var(--rounded); font-weight: 900; font-size: clamp(36px, 6vw, 68px); letter-spacing: -2px; line-height: 1; margin: 0 0 20px; color: #fff; }
+  .boop-landing .cta-band p { position: relative; font-size: 18px; opacity: 0.88; margin: 0 0 32px; }
+  .boop-landing .cta-btn { background: #fff; color: var(--accent); padding: 16px 28px; font-size: 16px; position: relative; }
+  .boop-landing .cta-btn:hover { background: #f1eef9; }
+
+  .boop-landing footer { padding: 60px 0 80px; border-top: 1px solid var(--lineSoft); }
+  .boop-landing .foot { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 32px; }
+  .boop-landing .foot-col { display: flex; flex-direction: column; gap: 10px; font-size: 14px; color: var(--muted); }
+  .boop-landing .foot-col-brand { max-width: 280px; }
+  .boop-landing .foot-col strong { color: var(--ink); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 1.2px; font-family: var(--mono); margin-bottom: 6px; }
+  .boop-landing .foot-col a:hover { color: var(--ink); }
+  .boop-landing .foot-tag { font-size: 13px; }
+  .boop-landing .foot-bottom { margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--lineSoft); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; font-size: 12px; color: var(--dim); font-family: var(--mono); }
+
+  .boop-landing .phone { width: 300px; margin: 0 auto; background: var(--ink); border-radius: 44px; padding: 10px; box-shadow: 0 40px 80px rgba(20,10,50,0.2); position: relative; }
+  .boop-landing .phone-inner { background: var(--bg); border-radius: 34px; overflow: hidden; aspect-ratio: 9 / 19.5; padding: 22px 18px; }
+  .boop-landing .phone-topbar { display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: var(--muted); font-family: var(--mono); margin-bottom: 18px; }
+  .boop-landing .phone h4 { margin: 14px 0 4px; font-family: var(--rounded); font-weight: 700; font-size: 22px; letter-spacing: -0.4px; }
+  .boop-landing .mono-sub { font-size: 12px; color: var(--muted); font-family: var(--mono); }
+  .boop-landing .progress { height: 4px; background: var(--line); border-radius: 999px; overflow: hidden; margin: 14px 0 18px; }
+  .boop-landing .progress > div { height: 100%; width: 62%; background: var(--accent); border-radius: 999px; }
+  .boop-landing .progress-lg { height: 6px; margin-bottom: 20px; }
+
+  .boop-landing .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px; margin: 40px 0; }
+  @media (max-width: 760px) { .boop-landing .stats { grid-template-columns: repeat(2, 1fr); } }
+  .boop-landing .stat { padding: 24px; background: var(--card); border: 1px solid var(--line); border-radius: 18px; }
+  .boop-landing .stat .n { font-family: var(--rounded); font-weight: 800; font-size: 36px; letter-spacing: -1px; }
+  .boop-landing .stat .l { font-size: 13px; color: var(--muted); margin-top: 2px; }
+
+  .boop-landing .faq-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px 48px; margin-top: 40px; }
+  @media (max-width: 760px) { .boop-landing .faq-grid { grid-template-columns: 1fr; } }
+  .boop-landing .faq-q { font-family: var(--rounded); font-weight: 700; font-size: 17px; margin: 0 0 8px; }
+  .boop-landing .faq-a { font-size: 14px; color: var(--muted); line-height: 1.6; margin: 0; }
+`;

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -12,24 +12,6 @@ export function Landing() {
 
   return (
     <div className="boop-landing">
-      <style>{boopStyles}</style>
-
-      <nav className="nav">
-        <div className="wrap nav-inner">
-          <a href="#" className="wordmark"><span className="dot" />boop</a>
-          <div className="nav-links">
-            <a href="#how">How it works</a>
-            <a href="#trust">Trust</a>
-            <a href="#pricing">Pricing</a>
-            <a href="#faq">FAQ</a>
-          </div>
-          <div className="nav-cta">
-            <Link to={appHref} className="btn btn-ghost">Sign in</Link>
-            <Link to={appHref} className="btn btn-primary">Get boop</Link>
-          </div>
-        </div>
-      </nav>
-
       <section className="hero">
         <div className="wrap">
           <h1><span className="mark" />boop.</h1>
@@ -41,6 +23,9 @@ export function Landing() {
             <Link to={appHref} className="btn btn-primary">Get boop — free</Link>
             <a href="#how" className="btn btn-ghost">See how it works →</a>
           </div>
+          <p className="hero-signin">
+            Already using boop? <Link to={appHref}>Sign in</Link>
+          </p>
           <div className="hero-meta">
             <span className="pip" />
             <span>no ads · no tracking · end-to-end signed</span>
@@ -314,6 +299,7 @@ export function Landing() {
               <a href="#">About</a>
               <a href="#">Manifesto</a>
               <a href="mailto:hello@boop.app">Contact</a>
+              <Link to={appHref}>Sign in</Link>
             </div>
           </div>
           <div className="foot-bottom">
@@ -325,185 +311,3 @@ export function Landing() {
     </div>
   );
 }
-
-const boopStyles = `
-  @import url('https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500&family=Nunito:wght@500;600;700;800;900&display=swap');
-
-  .boop-landing {
-    --bg: #fafaf7;
-    --card: #ffffff;
-    --panel: #f4f3ee;
-    --ink: #111014;
-    --muted: #6b6a74;
-    --dim: #a8a7b0;
-    --line: #ecebe6;
-    --lineSoft: #f3f2ec;
-    --accent: #6b3cff;
-    --accentSoft: #ece4ff;
-    --accentInk: #2a1570;
-    --ok: #1a7a4c;
-    --sans: 'Geist', 'Inter', system-ui, sans-serif;
-    --rounded: 'Nunito', system-ui, sans-serif;
-    --mono: 'Geist Mono', ui-monospace, monospace;
-
-    background: var(--bg);
-    color: var(--ink);
-    font-family: var(--sans);
-    -webkit-font-smoothing: antialiased;
-    overflow-x: hidden;
-    min-height: 100vh;
-  }
-  .boop-landing * { box-sizing: border-box; }
-  .boop-landing button { font: inherit; cursor: pointer; }
-  .boop-landing a { color: inherit; text-decoration: none; }
-  .boop-landing kbd { font-family: var(--mono); font-size: 0.85em; background: var(--panel); border: 1px solid var(--line); padding: 1px 6px; border-radius: 4px; }
-
-  .boop-landing .wrap { max-width: 1180px; margin: 0 auto; padding: 0 32px; }
-  @media (max-width: 720px) { .boop-landing .wrap { padding: 0 20px; } }
-
-  .boop-landing .nav { position: sticky; top: 0; z-index: 20; backdrop-filter: blur(14px); background: rgba(250,250,247,0.75); border-bottom: 1px solid var(--lineSoft); }
-  .boop-landing .nav-inner { display: flex; align-items: center; justify-content: space-between; height: 64px; }
-  .boop-landing .wordmark { display: inline-flex; align-items: center; gap: 8px; font-family: var(--rounded); font-weight: 800; font-size: 22px; letter-spacing: -0.8px; color: var(--ink); }
-  .boop-landing .wordmark .dot { width: 16px; height: 16px; border-radius: 50%; background: var(--accent); }
-  .boop-landing .wordmark-sm { font-size: 18px; gap: 6px; }
-  .boop-landing .wordmark-sm .dot { width: 13px; height: 13px; }
-  .boop-landing .nav-links { display: flex; gap: 28px; font-size: 14px; color: var(--muted); }
-  .boop-landing .nav-links a:hover { color: var(--ink); }
-  .boop-landing .nav-cta { display: flex; gap: 10px; align-items: center; }
-  .boop-landing .btn { border: none; border-radius: 999px; padding: 10px 18px; font-size: 14px; font-weight: 600; font-family: var(--sans); white-space: nowrap; transition: transform 120ms, box-shadow 120ms, background 120ms; display: inline-flex; align-items: center; justify-content: center; }
-  .boop-landing .btn-primary { background: var(--accent); color: #fff; box-shadow: 0 6px 18px rgba(107,60,255,0.3); }
-  .boop-landing .btn-primary:hover { transform: translateY(-1px); box-shadow: 0 10px 24px rgba(107,60,255,0.38); }
-  .boop-landing .btn-ghost { background: transparent; color: var(--ink); border: 1px solid var(--line); }
-  .boop-landing .btn-ghost:hover { background: var(--panel); }
-  @media (max-width: 820px) { .boop-landing .nav-links { display: none; } }
-
-  .boop-landing .hero { padding: 80px 0 60px; position: relative; }
-  .boop-landing .hero h1 { font-family: var(--rounded); font-weight: 900; font-size: clamp(48px, 8vw, 108px); letter-spacing: -3px; line-height: 0.95; margin: 0 0 24px; max-width: 900px; text-wrap: balance; }
-  .boop-landing .hero h1 .mark { display: inline-block; width: clamp(40px, 7vw, 90px); height: clamp(40px, 7vw, 90px); border-radius: 50%; background: var(--accent); vertical-align: -0.14em; margin-right: 14px; }
-  .boop-landing .hero-sub { font-size: clamp(17px, 2.1vw, 22px); color: var(--muted); max-width: 620px; line-height: 1.45; margin-bottom: 34px; text-wrap: pretty; }
-  .boop-landing .hero-cta { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
-  .boop-landing .hero-cta .btn-primary { padding: 14px 24px; font-size: 15px; }
-  .boop-landing .hero-cta .btn-ghost { padding: 14px 20px; font-size: 15px; }
-  .boop-landing .hero-meta { margin-top: 28px; display: inline-flex; align-items: center; gap: 14px; color: var(--muted); font-size: 13px; font-family: var(--mono); }
-  .boop-landing .hero-meta .pip { width: 6px; height: 6px; border-radius: 50%; background: var(--ok); }
-
-  .boop-landing .shot { margin-top: 56px; position: relative; padding: 40px; background: var(--panel); border-radius: 28px; border: 1px solid var(--line); overflow: hidden; }
-  .boop-landing .shot::before { content: ""; position: absolute; top: -80px; right: -100px; width: 340px; height: 340px; border-radius: 50%; background: radial-gradient(circle at center, rgba(107,60,255,0.2), transparent 70%); filter: blur(20px); }
-  .boop-landing .shot-grid { display: grid; grid-template-columns: 340px 1fr; gap: 24px; align-items: stretch; position: relative; }
-  @media (max-width: 880px) { .boop-landing .shot-grid { grid-template-columns: 1fr; } }
-
-  .boop-landing .mock { background: var(--card); border: 1px solid var(--line); border-radius: 20px; padding: 22px; box-shadow: 0 30px 80px rgba(20,10,50,0.1); }
-  .boop-landing .mock h3 { margin: 0; font-family: var(--rounded); font-weight: 700; font-size: 22px; letter-spacing: -0.4px; }
-  .boop-landing .mock-head { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 18px; }
-  .boop-landing .mock-tag { font-size: 11px; color: var(--muted); font-family: var(--mono); margin-bottom: 4px; }
-  .boop-landing .avatars { display: flex; }
-  .boop-landing .avy { width: 28px; height: 28px; border-radius: 50%; color: #fff; font-family: var(--rounded); font-weight: 800; font-size: 12px; display: inline-flex; align-items: center; justify-content: center; border: 2px solid var(--card); }
-  .boop-landing .avy + .avy { margin-left: -10px; }
-  .boop-landing .avy-violet { background: var(--accent); }
-  .boop-landing .avy-coral { background: #ff6e4a; }
-  .boop-landing .avy-green { background: #1a7a4c; }
-  .boop-landing .avy.big { width: 40px; height: 40px; font-size: 15px; border: none; }
-
-  .boop-landing .item { display: flex; align-items: center; gap: 12px; padding: 11px 0; border-bottom: 1px solid var(--lineSoft); }
-  .boop-landing .item:last-child { border-bottom: none; }
-  .boop-landing .box { width: 20px; height: 20px; border: 1.6px solid var(--dim); border-radius: 999px; display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; }
-  .boop-landing .box.on { background: var(--accent); border-color: var(--accent); }
-  .boop-landing .box.on::after { content: ""; width: 10px; height: 6px; border-left: 2px solid #fff; border-bottom: 2px solid #fff; transform: rotate(-45deg) translate(1px, -1px); }
-  .boop-landing .item .t { flex: 1; font-size: 14px; }
-  .boop-landing .item.done .t { text-decoration: line-through; color: var(--muted); }
-  .boop-landing .chip { font-size: 11px; font-family: var(--mono); background: var(--panel); color: var(--muted); padding: 2px 8px; border-radius: 999px; }
-  .boop-landing .chip-accent { color: var(--accent); background: var(--accentSoft); }
-
-  .boop-landing .section { padding: 80px 0; }
-  .boop-landing .section-tight { padding-top: 20px; }
-  .boop-landing .section-label { font-family: var(--mono); font-size: 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 2px; margin-bottom: 14px; display: inline-flex; align-items: center; gap: 8px; }
-  .boop-landing .section-label::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
-  .boop-landing .section-label-dark { color: rgba(255,255,255,0.6); }
-  .boop-landing .section h2 { font-family: var(--rounded); font-weight: 800; font-size: clamp(36px, 5vw, 60px); letter-spacing: -1.8px; line-height: 1.02; margin: 0 0 20px; max-width: 780px; text-wrap: balance; }
-  .boop-landing .section h2 em { font-style: normal; color: var(--accent); }
-  .boop-landing .section-lede { font-size: 18px; color: var(--muted); max-width: 620px; line-height: 1.5; margin-bottom: 48px; text-wrap: pretty; }
-
-  .boop-landing .features { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
-  @media (max-width: 900px) { .boop-landing .features { grid-template-columns: 1fr; } }
-  .boop-landing .feat { background: var(--card); border: 1px solid var(--line); border-radius: 20px; padding: 26px; transition: transform 180ms, box-shadow 180ms; }
-  .boop-landing .feat:hover { transform: translateY(-2px); box-shadow: 0 20px 50px rgba(20,10,50,0.08); }
-  .boop-landing .feat-icon { width: 44px; height: 44px; border-radius: 12px; background: var(--accentSoft); display: inline-flex; align-items: center; justify-content: center; color: var(--accent); margin-bottom: 18px; }
-  .boop-landing .feat h3 { margin: 0 0 8px; font-family: var(--rounded); font-weight: 700; font-size: 19px; letter-spacing: -0.3px; }
-  .boop-landing .feat p { margin: 0; font-size: 14px; color: var(--muted); line-height: 1.55; }
-
-  .boop-landing .trust { background: #0c0b10; color: #f1eef9; border-radius: 28px; padding: 60px 48px; position: relative; overflow: hidden; margin: 40px 0; }
-  .boop-landing .trust::before { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at 80% 20%, rgba(107,60,255,0.28), transparent 55%); }
-  .boop-landing .trust-grid { display: grid; grid-template-columns: 1.2fr 1fr; gap: 60px; align-items: center; position: relative; }
-  @media (max-width: 880px) { .boop-landing .trust-grid { grid-template-columns: 1fr; gap: 40px; } .boop-landing .trust { padding: 48px 28px; } }
-  .boop-landing .trust h2 { color: #fff; font-family: var(--rounded); font-weight: 800; font-size: clamp(32px, 4.5vw, 52px); letter-spacing: -1.5px; line-height: 1.05; margin: 0 0 16px; }
-  .boop-landing .trust p { font-size: 16px; color: rgba(241,238,249,0.7); line-height: 1.55; margin: 0 0 20px; max-width: 500px; }
-  .boop-landing .badge-card { background: rgba(255,255,255,0.05); backdrop-filter: blur(20px); border: 1px solid rgba(255,255,255,0.1); border-radius: 20px; padding: 28px; }
-  .boop-landing .badge-card .who { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; }
-  .boop-landing .badge-card .name { font-weight: 600; font-size: 15px; display: flex; align-items: center; gap: 6px; color: #fff; }
-  .boop-landing .badge-card .did { font-family: var(--mono); font-size: 11px; color: rgba(241,238,249,0.5); }
-  .boop-landing .badge-note { font-size: 14px; color: rgba(241,238,249,0.8); margin-bottom: 18px; line-height: 1.5; }
-  .boop-landing .signed { display: inline-flex; align-items: center; gap: 8px; font-size: 12px; font-family: var(--mono); color: #6bff9a; padding: 6px 10px; background: rgba(107,255,154,0.1); border-radius: 999px; }
-  .boop-landing .signed-dot { width: 6px; height: 6px; border-radius: 50%; background: #6bff9a; }
-
-  .boop-landing .pullquote { padding: 100px 0; text-align: center; }
-  .boop-landing .pullquote blockquote { font-family: var(--rounded); font-weight: 600; font-size: clamp(28px, 4vw, 44px); letter-spacing: -1.2px; line-height: 1.2; margin: 0 auto; max-width: 840px; text-wrap: balance; color: var(--ink); }
-  .boop-landing .pullquote cite { display: block; font-style: normal; font-size: 14px; color: var(--muted); font-family: var(--mono); margin-top: 28px; }
-
-  .boop-landing .plans { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
-  @media (max-width: 900px) { .boop-landing .plans { grid-template-columns: 1fr; } }
-  .boop-landing .plan { background: var(--card); border: 1px solid var(--line); border-radius: 20px; padding: 28px; display: flex; flex-direction: column; }
-  .boop-landing .plan.hero-plan { background: var(--ink); color: #fff; border: none; }
-  .boop-landing .plan.hero-plan .price, .boop-landing .plan.hero-plan .plan-name { color: #fff; }
-  .boop-landing .plan-name { font-family: var(--rounded); font-weight: 700; font-size: 20px; margin-bottom: 4px; }
-  .boop-landing .plan-desc { font-size: 13px; color: var(--muted); margin-bottom: 24px; }
-  .boop-landing .plan.hero-plan .plan-desc { color: rgba(255,255,255,0.6); }
-  .boop-landing .price { font-family: var(--rounded); font-weight: 800; font-size: 44px; letter-spacing: -1.5px; line-height: 1; }
-  .boop-landing .price small { font-size: 14px; color: var(--muted); font-weight: 500; margin-left: 4px; }
-  .boop-landing .plan.hero-plan .price small { color: rgba(255,255,255,0.6); }
-  .boop-landing .plan ul { list-style: none; padding: 0; margin: 24px 0; flex: 1; }
-  .boop-landing .plan li { font-size: 14px; padding: 8px 0; display: flex; gap: 10px; align-items: flex-start; color: var(--ink); }
-  .boop-landing .plan.hero-plan li { color: rgba(255,255,255,0.85); }
-  .boop-landing .plan li::before { content: ""; width: 14px; height: 14px; border-radius: 50%; background: var(--accentSoft); flex-shrink: 0; margin-top: 3px; background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M3 6.5l2 2 4.5-5' stroke='%236b3cff' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round' fill='none'/></svg>"); background-position: center; background-repeat: no-repeat; }
-  .boop-landing .plan.hero-plan li::before { background-color: rgba(107,60,255,0.3); background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12'><path d='M3 6.5l2 2 4.5-5' stroke='white' stroke-width='1.6' stroke-linecap='round' stroke-linejoin='round' fill='none'/></svg>"); }
-  .boop-landing .plan-cta { text-align: center; width: 100%; }
-  .boop-landing .plan-cta-invert { background: #fff; color: var(--accent); }
-  .boop-landing .plan-cta-invert:hover { background: #f1eef9; }
-
-  .boop-landing .cta-wrap { padding: 60px 0; }
-  .boop-landing .cta-band { background: var(--accent); color: #fff; border-radius: 28px; padding: 80px 40px; text-align: center; position: relative; overflow: hidden; }
-  .boop-landing .cta-band::before { content: ""; position: absolute; top: -100px; left: -100px; width: 300px; height: 300px; border-radius: 50%; background: rgba(255,255,255,0.1); }
-  .boop-landing .cta-band::after { content: ""; position: absolute; bottom: -120px; right: -80px; width: 400px; height: 400px; border-radius: 50%; background: rgba(255,255,255,0.08); }
-  .boop-landing .cta-band h2 { position: relative; font-family: var(--rounded); font-weight: 900; font-size: clamp(36px, 6vw, 68px); letter-spacing: -2px; line-height: 1; margin: 0 0 20px; color: #fff; }
-  .boop-landing .cta-band p { position: relative; font-size: 18px; opacity: 0.88; margin: 0 0 32px; }
-  .boop-landing .cta-btn { background: #fff; color: var(--accent); padding: 16px 28px; font-size: 16px; position: relative; }
-  .boop-landing .cta-btn:hover { background: #f1eef9; }
-
-  .boop-landing footer { padding: 60px 0 80px; border-top: 1px solid var(--lineSoft); }
-  .boop-landing .foot { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 32px; }
-  .boop-landing .foot-col { display: flex; flex-direction: column; gap: 10px; font-size: 14px; color: var(--muted); }
-  .boop-landing .foot-col-brand { max-width: 280px; }
-  .boop-landing .foot-col strong { color: var(--ink); font-weight: 600; font-size: 12px; text-transform: uppercase; letter-spacing: 1.2px; font-family: var(--mono); margin-bottom: 6px; }
-  .boop-landing .foot-col a:hover { color: var(--ink); }
-  .boop-landing .foot-tag { font-size: 13px; }
-  .boop-landing .foot-bottom { margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--lineSoft); display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px; font-size: 12px; color: var(--dim); font-family: var(--mono); }
-
-  .boop-landing .phone { width: 300px; margin: 0 auto; background: var(--ink); border-radius: 44px; padding: 10px; box-shadow: 0 40px 80px rgba(20,10,50,0.2); position: relative; }
-  .boop-landing .phone-inner { background: var(--bg); border-radius: 34px; overflow: hidden; aspect-ratio: 9 / 19.5; padding: 22px 18px; }
-  .boop-landing .phone-topbar { display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: var(--muted); font-family: var(--mono); margin-bottom: 18px; }
-  .boop-landing .phone h4 { margin: 14px 0 4px; font-family: var(--rounded); font-weight: 700; font-size: 22px; letter-spacing: -0.4px; }
-  .boop-landing .mono-sub { font-size: 12px; color: var(--muted); font-family: var(--mono); }
-  .boop-landing .progress { height: 4px; background: var(--line); border-radius: 999px; overflow: hidden; margin: 14px 0 18px; }
-  .boop-landing .progress > div { height: 100%; width: 62%; background: var(--accent); border-radius: 999px; }
-  .boop-landing .progress-lg { height: 6px; margin-bottom: 20px; }
-
-  .boop-landing .stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px; margin: 40px 0; }
-  @media (max-width: 760px) { .boop-landing .stats { grid-template-columns: repeat(2, 1fr); } }
-  .boop-landing .stat { padding: 24px; background: var(--card); border: 1px solid var(--line); border-radius: 18px; }
-  .boop-landing .stat .n { font-family: var(--rounded); font-weight: 800; font-size: 36px; letter-spacing: -1px; }
-  .boop-landing .stat .l { font-size: 13px; color: var(--muted); margin-top: 2px; }
-
-  .boop-landing .faq-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 28px 48px; margin-top: 40px; }
-  @media (max-width: 760px) { .boop-landing .faq-grid { grid-template-columns: 1fr; } }
-  .boop-landing .faq-q { font-family: var(--rounded); font-weight: 700; font-size: 17px; margin: 0 0 8px; }
-  .boop-landing .faq-a { font-size: 14px; color: var(--muted); line-height: 1.6; margin: 0; }
-`;

--- a/src/pages/ListView.tsx
+++ b/src/pages/ListView.tsx
@@ -699,7 +699,17 @@ export function ListView() {
           {/* Title and info - takes remaining space */}
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
-              <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-gray-100 break-words min-w-0">
+              <h1
+                className="text-gray-900 dark:text-gray-100 break-words min-w-0"
+                style={{
+                  fontFamily: 'Nunito, system-ui, sans-serif',
+                  fontWeight: 700,
+                  fontSize: 'clamp(24px, 4.5vw, 32px)',
+                  letterSpacing: -0.9,
+                  lineHeight: 1.05,
+                  margin: 0,
+                }}
+              >
                 {list.name}
               </h1>
               {streak > 0 && <StreakBadge streak={streak} size="sm" />}
@@ -712,24 +722,61 @@ export function ListView() {
               anchorTxId={publicationStatus?.anchorTxId}
             />
             </div>
-          
+
             {/* Progress and collaborators info */}
-            <div className="flex items-center gap-2 text-xs sm:text-sm">
+            <div
+              className="flex items-center gap-2 text-[12px] mt-1 text-stone-500 dark:text-stone-400"
+              style={{ fontFamily: 'Geist Mono, ui-monospace, monospace' }}
+            >
             {totalCount > 0 && (
-              <span className="text-gray-500 dark:text-gray-400">
+              <span>
                 {checkedCount}/{totalCount} done
               </span>
             )}
-            
+
             {isPublished && (
               <>
-                <span className="text-gray-300 dark:text-gray-600">•</span>
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400 text-xs sm:text-sm">
-                  🌐 Shared
+                <span className="text-stone-300 dark:text-stone-600">·</span>
+                <span className="inline-flex items-center gap-1">
+                  <span
+                    style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: '50%',
+                      background: '#1a7a4c',
+                      display: 'inline-block',
+                    }}
+                    aria-hidden="true"
+                  />
+                  shared
                 </span>
               </>
             )}
             </div>
+
+            {/* Progress bar — only show if there are items */}
+            {totalCount > 0 && (
+              <div className="flex items-center gap-2.5 mt-3 max-w-md">
+                <div className="flex-1 h-[6px] rounded-full overflow-hidden bg-stone-200/70 dark:bg-stone-700/60">
+                  <div
+                    className="h-full rounded-full transition-[width] duration-300"
+                    style={{
+                      width: `${Math.round((checkedCount / totalCount) * 100)}%`,
+                      background: 'var(--boop-accent)',
+                    }}
+                  />
+                </div>
+                <span
+                  className="text-[11px] font-semibold tabular-nums"
+                  style={{
+                    color: 'var(--boop-accent)',
+                    fontFamily: 'Geist Mono, ui-monospace, monospace',
+                  }}
+                >
+                  {Math.round((checkedCount / totalCount) * 100)}%
+                </span>
+              </div>
+            )}
           </div>
 
           {/* Compact action buttons */}

--- a/src/pages/ListView.tsx
+++ b/src/pages/ListView.tsx
@@ -914,7 +914,7 @@ export function ListView() {
       {totalCount > 0 && (
         <div className="mb-4 bg-amber-100 dark:bg-amber-900/30 rounded-full h-2.5 overflow-hidden">
           <div 
-            className="h-full bg-gradient-to-r from-amber-400 to-amber-500 dark:from-amber-500 dark:to-amber-400 transition-all duration-500 ease-out rounded-full"
+            className="h-full bg-amber-500 transition-all duration-500 ease-out rounded-full"
             style={{ width: `${(checkedCount / totalCount) * 100}%` }}
           />
         </div>
@@ -984,8 +984,8 @@ export function ListView() {
                   {/* Aisle section header — highlights when dragging over */}
                   <div className={`flex items-center gap-2 px-3 py-2 rounded-t-xl border-b transition-colors duration-150 ${
                     dragOverAisleId === aisle.id && groceryTouchDrag.state.draggedId
-                      ? "bg-gradient-to-r from-amber-100 to-orange-100 dark:from-amber-900/40 dark:to-orange-900/40 border-amber-400 dark:border-amber-600 ring-2 ring-amber-400 dark:ring-amber-600"
-                      : "bg-gradient-to-r from-amber-50 to-orange-50 dark:from-gray-700 dark:to-gray-750 border-amber-100 dark:border-gray-600"
+                      ? "bg-amber-100 dark:bg-amber-900/40 border-amber-400 dark:border-amber-600 ring-2 ring-amber-400 dark:ring-amber-600"
+                      : "bg-amber-50 dark:bg-gray-700 border-amber-100 dark:border-gray-600"
                   }`}>
                     <span className="text-lg">{aisle.emoji}</span>
                     <span className="font-semibold text-sm text-gray-800 dark:text-gray-200">{aisle.name}</span>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -114,12 +114,12 @@ export function Login({ embedded = false }: LoginProps) {
   };
 
   return (
-    <div className="min-h-screen bg-amber-50 flex flex-col items-center justify-center p-4">
+    <div className="min-h-screen flex flex-col items-center justify-center p-4" style={{ background: 'var(--boop-bg)' }}>
       {/* Brand header */}
       {!embedded && (
-        <Link to="/" className="flex items-center gap-2 mb-8 text-amber-900 hover:text-amber-700 transition-colors">
-          <span className="text-3xl">💩</span>
-          <span className="font-black text-xl">Poo App</span>
+        <Link to="/" className="boop-wordmark text-[26px] mb-8 hover:opacity-80 transition-opacity" aria-label="boop">
+          <span className="boop-dot" aria-hidden="true" />
+          <span>boop</span>
         </Link>
       )}
 

--- a/src/pages/PriorityFocus.tsx
+++ b/src/pages/PriorityFocus.tsx
@@ -174,7 +174,6 @@ function PriorityItem({
 function NoPriorityItemsEmptyState() {
   return (
     <EmptyState
-      emoji="🎯"
       title="No high-priority items"
       description="You don't have any high-priority items across your lists. When you mark items as high priority, they'll appear here for easy focus."
     />

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -11,7 +11,7 @@ export function Privacy() {
       <header className="bg-amber-900 text-amber-50 py-6 px-4">
         <div className="max-w-3xl mx-auto">
           <a href="/" className="flex items-center gap-2 mb-4 text-amber-200 hover:text-white transition-colors text-sm">
-            &larr; Back to Poo App
+            &larr; Back to boop
           </a>
           <h1 className="text-3xl font-black">Privacy Policy</h1>
           <p className="text-amber-200 mt-1 text-sm">Last updated: March 2026</p>
@@ -22,7 +22,7 @@ export function Privacy() {
         <section className="mb-8">
           <h2 className="text-xl font-bold text-amber-900 mb-3">Overview</h2>
           <p className="text-amber-800 leading-relaxed">
-            Poo App (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;) is a todo list and task management application.
+            boop (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;) is a todo list and task management application.
             We take your privacy seriously. This policy explains what data we collect, how we use it,
             and your rights regarding your personal information.
           </p>
@@ -41,7 +41,7 @@ export function Privacy() {
         <section className="mb-8">
           <h2 className="text-xl font-bold text-amber-900 mb-3">How We Use Your Data</h2>
           <ul className="space-y-2 text-amber-800">
-            <li>To provide and improve the Poo App service.</li>
+            <li>To provide and improve the boop service.</li>
             <li>To sync your lists across devices.</li>
             <li>To enable list sharing with collaborators you invite.</li>
             <li>To send transactional emails (account verification, password reset).</li>
@@ -73,7 +73,7 @@ export function Privacy() {
         <section className="mb-8">
           <h2 className="text-xl font-bold text-amber-900 mb-3">Offline Data</h2>
           <p className="text-amber-800 leading-relaxed">
-            Poo App stores a local copy of your lists on your device to support offline access.
+            boop stores a local copy of your lists on your device to support offline access.
             This data is stored in your device&apos;s local storage and is not accessible to other apps.
           </p>
         </section>
@@ -91,7 +91,7 @@ export function Privacy() {
         <section className="mb-8">
           <h2 className="text-xl font-bold text-amber-900 mb-3">Children&apos;s Privacy</h2>
           <p className="text-amber-800 leading-relaxed">
-            Poo App is not directed at children under 13 years of age. We do not knowingly collect
+            boop is not directed at children under 13 years of age. We do not knowingly collect
             personal information from children under 13.
           </p>
         </section>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -90,14 +90,32 @@ export function Profile() {
       {/* Profile Card */}
       <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-lg overflow-hidden">
         {/* Header with avatar */}
-        <div className="bg-gradient-to-r from-amber-500 to-orange-500 px-6 py-8 text-center">
-          <div className="w-24 h-24 mx-auto bg-white dark:bg-gray-800 rounded-full flex items-center justify-center text-5xl shadow-lg mb-4">
-            💩
+        <div className="px-6 py-8 text-center" style={{ background: 'var(--boop-accent)' }}>
+          <div
+            className="w-20 h-20 mx-auto rounded-full flex items-center justify-center text-white shadow-lg mb-4"
+            style={{
+              background: 'rgba(255,255,255,0.15)',
+              fontFamily: 'Nunito, system-ui, sans-serif',
+              fontWeight: 800,
+              fontSize: 34,
+              letterSpacing: -1,
+            }}
+            aria-hidden="true"
+          >
+            {(displayName || email || 'B').trim().charAt(0).toUpperCase()}
           </div>
-          <h1 className="text-2xl font-bold text-white mb-1">
+          <h1
+            className="text-white mb-1"
+            style={{
+              fontFamily: 'Nunito, system-ui, sans-serif',
+              fontWeight: 800,
+              fontSize: 24,
+              letterSpacing: -0.5,
+            }}
+          >
             {displayName || email?.split('@')[0] || 'Anonymous'}
           </h1>
-          <p className="text-amber-100 text-sm">
+          <p className="text-white/75 text-sm">
             {email || 'No email set'}
           </p>
         </div>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -289,7 +289,7 @@ export function Profile() {
         {/* Motivational footer */}
         {completionRate >= 80 && (
           <div className="px-6 pb-6">
-            <div className="bg-gradient-to-r from-amber-100 to-orange-100 dark:from-amber-900/30 dark:to-orange-900/30 rounded-xl p-4 text-center">
+            <div className="bg-amber-100 dark:bg-amber-900/30 rounded-xl p-4 text-center">
               <p className="text-2xl mb-2">🏆</p>
               <p className="font-medium text-amber-800 dark:text-amber-200">
                 Amazing! You're a productivity champion!
@@ -300,7 +300,7 @@ export function Profile() {
         
         {completionRate < 80 && completionRate >= 50 && (
           <div className="px-6 pb-6">
-            <div className="bg-gradient-to-r from-amber-100 to-orange-100 dark:from-amber-900/30 dark:to-orange-900/30 rounded-xl p-4 text-center">
+            <div className="bg-amber-100 dark:bg-amber-900/30 rounded-xl p-4 text-center">
               <p className="text-2xl mb-2">💪</p>
               <p className="font-medium text-amber-800 dark:text-amber-200">
                 Great progress! Keep up the momentum!
@@ -311,7 +311,7 @@ export function Profile() {
         
         {completionRate < 50 && totalItems > 0 && (
           <div className="px-6 pb-6">
-            <div className="bg-gradient-to-r from-orange-100 to-amber-100 dark:from-orange-900/30 dark:to-amber-900/30 rounded-xl p-4 text-center">
+            <div className="bg-amber-100 dark:bg-amber-900/30 rounded-xl p-4 text-center">
               <p className="text-2xl mb-2">🚀</p>
               <p className="font-medium text-orange-800 dark:text-orange-200">
                 You've got this! Every item counts!

--- a/src/pages/PublicList.tsx
+++ b/src/pages/PublicList.tsx
@@ -75,8 +75,9 @@ export function PublicList() {
       <header className="bg-white shadow-sm">
         <div className="container mx-auto p-4">
           <div className="flex items-center justify-between">
-            <Link to="/" className="text-xl font-bold hover:text-gray-700">
-              Poo App
+            <Link to="/" className="boop-wordmark text-[20px] hover:opacity-80 transition-opacity" aria-label="boop">
+              <span className="boop-dot" aria-hidden="true" />
+              <span>boop</span>
             </Link>
             <span className="text-sm text-gray-500">Public List</span>
           </div>
@@ -186,7 +187,7 @@ export function PublicList() {
             to="/login"
             className="inline-block px-6 py-2 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700"
           >
-            Sign up for Poo App
+            Sign up for boop
           </Link>
         </div>
       </main>

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -11,7 +11,7 @@ export function Terms() {
       <header className="bg-amber-900 text-amber-50 py-6 px-4">
         <div className="max-w-3xl mx-auto">
           <a href="/" className="flex items-center gap-2 mb-4 text-amber-200 hover:text-white transition-colors text-sm">
-            &larr; Back to Poo App
+            &larr; Back to boop
           </a>
           <h1 className="text-3xl font-black">Terms of Service</h1>
           <p className="text-amber-200 mt-1 text-sm">Last updated: March 2026</p>
@@ -22,7 +22,7 @@ export function Terms() {
         <section className="mb-8">
           <h2 className="text-xl font-bold text-amber-900 mb-3">Agreement to Terms</h2>
           <p className="text-amber-800 leading-relaxed">
-            By accessing or using Poo App (&quot;the Service&quot;), operated by Aviary Tech (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;),
+            By accessing or using boop (&quot;the Service&quot;), operated by Aviary Tech (&quot;we&quot;, &quot;us&quot;, &quot;our&quot;),
             you agree to be bound by these Terms of Service. If you do not agree, do not use the Service.
           </p>
         </section>

--- a/src/workers/service-worker.ts
+++ b/src/workers/service-worker.ts
@@ -183,7 +183,7 @@ self.addEventListener('push', (event) => {
 
   try {
     const data = event.data.json();
-    const title = data.title || '💩 Poo App';
+    const title = data.title || 'boop';
     const options = {
       body: data.body || 'You have a notification',
       icon: '/pwa-192x192.png',
@@ -203,7 +203,7 @@ self.addEventListener('push', (event) => {
     // Fallback for plain text push
     const body = event.data.text();
     event.waitUntil(
-      self.registration.showNotification('💩 Poo App', {
+      self.registration.showNotification('boop', {
         body,
         icon: '/pwa-192x192.png',
       })


### PR DESCRIPTION
## Summary
- Full rebrand from "Poo App" (brown/amber + 💩) to **boop** (cream/violet + accent dot wordmark)
- Landing page ported from the Boop Landing design handoff with new hero, "how it works", trust, pricing, and FAQ sections
- Onboarding, Settings, Compare pages, PWA manifest, favicon, theme colors, and social meta tags all updated to match
- Tagline "Lists, booped." dropped — just use the app name "boop"

## Test plan
- [ ] Landing page renders with new palette and hero ("boop.") on light + dark
- [ ] Onboarding welcome step shows the boop dot mark and new copy
- [ ] Settings "About" card shows the boop wordmark
- [ ] `/compare/todoist`, `/compare/reminders`, `/compare/things` render with boop branding
- [ ] PWA install shows "boop" as app name; favicon is the violet dot, not 💩
- [ ] OG / Twitter share previews show "boop" title and new description
- [ ] Existing users with `pooapp:darkMode` in localStorage still get correct theme (fallback preserved)