### PR TITLE
refactor: move authenticated root route from /app to /d

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -25,7 +25,7 @@ async function gotoHome(
 ) {
   await mockConvexWebSocket(page, { existingListCount });
   await seedAuthSession(page);
-  await page.goto("/app");
+  await page.goto("/d");
   await expect(page.getByRole("heading", { name: /Your lists|Welcome in/i })).toBeVisible({
     timeout: 10000,
   });

--- a/e2e/delete-list.spec.ts
+++ b/e2e/delete-list.spec.ts
@@ -7,7 +7,7 @@
  *   3. Clicking "Delete list" opens the Delete confirmation dialog
  *   4. Dialog shows the list name in the confirmation text
  *   5. Cancel button closes the dialog without navigating
- *   6. Confirm delete triggers mutation and navigates back to /app
+ *   6. Confirm delete triggers mutation and navigates back to /d
  *
  * The Convex mock auto-succeeds any mutation (deleteList returns null → onDeleted() fires).
  */
@@ -84,7 +84,7 @@ test.describe("Delete list flow", () => {
     await expect(page).toHaveURL(new RegExp(MOCK_LIST_ID));
   });
 
-  test("6. confirming delete triggers mutation and navigates to /app", async ({ page }) => {
+  test("6. confirming delete triggers mutation and navigates to /d", async ({ page }) => {
     await gotoListPage(page);
 
     await page.getByRole("button", { name: "More actions" }).click();
@@ -94,8 +94,8 @@ test.describe("Delete list flow", () => {
     // Click the destructive Delete button (inside the dialog)
     await page.getByRole("alertdialog").getByRole("button", { name: "Delete" }).click();
 
-    // After onDeleted() is called, the app navigates to /app
-    await expect(page).toHaveURL("/app", { timeout: 10000 });
+    // After onDeleted() is called, the app navigates to /d
+    await expect(page).toHaveURL("/d", { timeout: 10000 });
     await expect(
       page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });

--- a/e2e/identity.spec.ts
+++ b/e2e/identity.spec.ts
@@ -13,8 +13,8 @@ import { seedAuthSession } from "./fixtures/auth";
 import { mockConvexWebSocket } from "./fixtures/convex";
 
 test.describe("Authentication / Identity flow", () => {
-  test("unauthenticated user at /app redirects to /login", async ({ page }) => {
-    await page.goto("/app");
+  test("unauthenticated user at /d redirects to /login", async ({ page }) => {
+    await page.goto("/d");
     await expect(page).toHaveURL("/login");
   });
 
@@ -28,18 +28,18 @@ test.describe("Authentication / Identity flow", () => {
     ).toBeVisible();
   });
 
-  test("authenticated user at /login is redirected to /app", async ({ page }) => {
+  test("authenticated user at /login is redirected to /d", async ({ page }) => {
     await mockConvexWebSocket(page, { existingListCount: 0 });
     await seedAuthSession(page);
-    // Login page redirects authenticated users directly to /app
+    // Login page redirects authenticated users directly to /d
     await page.goto("/login");
-    await expect(page).toHaveURL("/app");
+    await expect(page).toHaveURL("/d");
   });
 
   test("auth session persists after page reload", async ({ page }) => {
     await mockConvexWebSocket(page, { existingListCount: 0 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     // Confirm we landed on the authenticated home page
     await expect(
@@ -49,7 +49,7 @@ test.describe("Authentication / Identity flow", () => {
     // Reload — localStorage still has the JWT so no redirect to /login
     await page.reload();
 
-    await expect(page).toHaveURL("/app");
+    await expect(page).toHaveURL("/d");
     await expect(
       page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });

--- a/e2e/lists.spec.ts
+++ b/e2e/lists.spec.ts
@@ -14,7 +14,7 @@ test.describe("List management", () => {
   test("shows empty state when no lists exist", async ({ page }) => {
     await mockConvexWebSocket(page, { existingListCount: 0 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     await expect(
       page.getByRole("heading", { name: /Your lists|Welcome in/i }),
@@ -28,7 +28,7 @@ test.describe("List management", () => {
   test("opens create list modal via template picker", async ({ page }) => {
     await mockConvexWebSocket(page, { existingListCount: 0 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     await page.getByRole("button", { name: "Create new list" }).click({ timeout: 10000 });
 
@@ -48,7 +48,7 @@ test.describe("List management", () => {
   test("creates a new list", async ({ page }) => {
     await mockConvexWebSocket(page, { existingListCount: 0 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     await page.getByRole("button", { name: "Create new list" }).click({ timeout: 10000 });
     await expect(
@@ -69,7 +69,7 @@ test.describe("List management", () => {
   test("create list button is disabled when name is empty", async ({ page }) => {
     await mockConvexWebSocket(page, { existingListCount: 0 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     await page.getByRole("button", { name: "Create new list" }).click({ timeout: 10000 });
     await expect(
@@ -87,7 +87,7 @@ test.describe("List management", () => {
   test("can cancel list creation", async ({ page }) => {
     await mockConvexWebSocket(page, { existingListCount: 0 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     await page.getByRole("button", { name: "Create new list" }).click({ timeout: 10000 });
     await expect(

--- a/e2e/offline.spec.ts
+++ b/e2e/offline.spec.ts
@@ -20,7 +20,7 @@ import { mockConvexWebSocket } from "./fixtures/convex";
 async function gotoAppOnline(page: import("@playwright/test").Page) {
   await mockConvexWebSocket(page, { existingListCount: 0 });
   await seedAuthSession(page);
-  await page.goto("/app");
+  await page.goto("/d");
   await expect(
     page.getByRole("heading", { name: /Your lists|Welcome in/i }),
   ).toBeVisible({ timeout: 10000 });

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -181,7 +181,7 @@ test.describe("Onboarding: 2-step new user flow (POO-45)", () => {
     // existingListCount=0 triggers demo list auto-creation path
     await mockConvexWebSocket(page, { existingListCount: 0 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     // Wait for home page to settle
     await expect(
@@ -199,7 +199,7 @@ test.describe("Onboarding: 2-step new user flow (POO-45)", () => {
   }) => {
     await mockConvexWebSocket(page, { existingListCount: 0 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     // Wait for the home page to load and the demo creation effect to run
     await expect(
@@ -222,7 +222,7 @@ test.describe("Onboarding: 2-step new user flow (POO-45)", () => {
     // existingListCount=1 means user already has lists — skip demo creation
     await mockConvexWebSocket(page, { existingListCount: 1 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     await expect(
       page.getByRole("heading", { name: /Your lists|Welcome in/i }),
@@ -247,7 +247,7 @@ test.describe("Onboarding: 2-step new user flow (POO-45)", () => {
     // Start with 1 existing list so demo is skipped; inviteNudgeDone is NOT set
     await mockConvexWebSocket(page, { existingListCount: 1 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     await expect(
       page.getByRole("heading", { name: /Your lists|Welcome in/i }),
@@ -282,7 +282,7 @@ test.describe("Onboarding: 2-step new user flow (POO-45)", () => {
   test("5. InviteNudge is dismissed by clicking Later", async ({ page }) => {
     await mockConvexWebSocket(page, { existingListCount: 1 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     await expect(
       page.getByRole("heading", { name: /Your lists|Welcome in/i }),
@@ -327,7 +327,7 @@ test.describe("Onboarding: 2-step new user flow (POO-45)", () => {
 
     await mockConvexWebSocket(page, { existingListCount: 1 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     await expect(
       page.getByRole("heading", { name: /Your lists|Welcome in/i }),

--- a/e2e/profile.spec.ts
+++ b/e2e/profile.spec.ts
@@ -5,7 +5,7 @@
  *   1. /profile route renders the Profile heading (user display name)
  *   2. Stats grid is visible (Lists Created, Shared Lists, Items Done, Completion Rate)
  *   3. Plan section shows "free" with an Upgrade link for free-plan users
- *   4. Back to lists link navigates to /app
+ *   4. Back to lists link navigates to /d
  *   5. User email is shown in profile header
  *
  * All tests use seedAuthSession() + mockConvexWebSocket() (free plan = getUserSubscription: null).
@@ -66,12 +66,12 @@ test.describe("Profile page", () => {
     await expect(upgradeLink).toHaveAttribute("href", "/pricing");
   });
 
-  test("6. Back to lists link navigates to /app", async ({ page }) => {
+  test("6. Back to lists link navigates to /d", async ({ page }) => {
     await gotoProfile(page);
 
     await page.getByRole("link", { name: /Back to lists/i }).click();
 
-    await expect(page).toHaveURL("/app", { timeout: 10000 });
+    await expect(page).toHaveURL("/d", { timeout: 10000 });
     await expect(
       page.getByRole("heading", { name: /Your lists|Welcome in/i }),
     ).toBeVisible({ timeout: 10000 });

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -19,7 +19,7 @@ import { mockConvexWebSocket } from "./fixtures/convex";
 async function openSettings(page: import("@playwright/test").Page) {
   await mockConvexWebSocket(page, { existingListCount: 0 });
   await seedAuthSession(page);
-  await page.goto("/app");
+  await page.goto("/d");
 
   await expect(
     page.getByRole("heading", { name: /Your lists|Welcome in/i }),

--- a/e2e/smoke-upgrade-journey.spec.ts
+++ b/e2e/smoke-upgrade-journey.spec.ts
@@ -147,7 +147,7 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
     ).toBeVisible();
   });
 
-  test("8. sign-up: completing OTP redirects to /app", async ({ page }) => {
+  test("8. sign-up: completing OTP redirects to /d", async ({ page }) => {
     await mockConvexWebSocket(page);
     await mockAuthEndpoints(page);
 
@@ -160,7 +160,7 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
     await page.getByLabel("Digit 1").click();
     await page.keyboard.type("123456");
 
-    await expect(page).toHaveURL("/app", { timeout: 10000 });
+    await expect(page).toHaveURL("/d", { timeout: 10000 });
   });
 
   // =========================================================================
@@ -172,7 +172,7 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
   }) => {
     await mockConvexWebSocket(page, { existingListCount: 0 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     await expect(
       page.getByRole("heading", { name: /Your lists|Welcome in/i }),
@@ -188,7 +188,7 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
   }) => {
     await mockConvexWebSocket(page, { existingListCount: 0 });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     await page.getByRole("button", { name: "Create new list" }).click({ timeout: 10000 });
     // Template picker opens first — select "Blank List" to get the create modal
@@ -209,7 +209,7 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
       failCreateList: true,
     });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     // Wait for home page to finish loading
     await page.getByRole("button", { name: "Create new list" }).waitFor({
@@ -242,7 +242,7 @@ test.describe("Smoke: landing to paid upgrade journey", () => {
       failCreateList: true,
     });
     await seedAuthSession(page);
-    await page.goto("/app");
+    await page.goto("/d");
 
     await page.getByRole("button", { name: "Create new list" }).waitFor({
       state: "visible",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -77,7 +77,7 @@
       "name": "New List",
       "short_name": "New",
       "description": "Create a new list",
-      "url": "/app?action=new",
+      "url": "/d?action=new",
       "icons": [{"src": "/icons/new-list.png", "sizes": "96x96"}]
     }
   ],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,7 +56,7 @@ function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
       <header className="flex-shrink-0 sticky top-0 z-40 bg-stone-50/90 dark:bg-gray-950/90 backdrop-blur-md border-b border-stone-200 dark:border-gray-800 safe-area-inset-top">
         <div className="container mx-auto px-4 py-3 flex items-center justify-between">
           <Link
-            to="/app"
+            to="/d"
             onClick={() => haptic('light')}
             className="boop-wordmark text-[20px] leading-none hover:opacity-80 transition-opacity"
             aria-label="boop — home"
@@ -219,13 +219,13 @@ function App() {
         <Routes>
           {/* Public routes - accessible without authentication */}
           <Route path="/invite/:code" element={<InviteLanding />} />
-          <Route path="/login" element={isAuthenticated ? <Navigate to="/app" replace /> : <Login />} />
+          <Route path="/login" element={isAuthenticated ? <Navigate to="/d" replace /> : <Login />} />
           <Route path="/join/:listId/:token" element={<JoinList />} />
           <Route path="/public/:did" element={<PublicList />} />
           <Route path="/:userPath/resources/:resourceId" element={<SharedListResource />} />
 
           {/* Landing page for unauthenticated, redirect to app if logged in */}
-          <Route path="/" element={isAuthenticated ? <Navigate to="/app" replace /> : <Landing />} />
+          <Route path="/" element={isAuthenticated ? <Navigate to="/d" replace /> : <Landing />} />
 
           {/* Pricing - accessible to all, authenticated or not */}
           <Route path="/pricing" element={<Pricing />} />
@@ -234,14 +234,14 @@ function App() {
           <Route path="/compare/:competitor" element={<Compare />} />
 
           {/* Protected routes - require authentication */}
-          <Route path="/app" element={<ProtectedRoute><Home /></ProtectedRoute>} />
+          <Route path="/d" element={<ProtectedRoute><Home /></ProtectedRoute>} />
           <Route path="/profile" element={<ProtectedRoute><Profile /></ProtectedRoute>} />
           <Route path="/templates" element={<ProtectedRoute><Templates /></ProtectedRoute>} />
           <Route path="/priority" element={<ProtectedRoute><PriorityFocus /></ProtectedRoute>} />
           <Route path="/list/:id" element={<ProtectedRoute><ListView /></ProtectedRoute>} />
 
           {/* Fallback - redirect to app (AuthGuard will handle login redirect if needed) */}
-          <Route path="*" element={<ProtectedRoute><Navigate to="/app" replace /></ProtectedRoute>} />
+          <Route path="*" element={<ProtectedRoute><Navigate to="/d" replace /></ProtectedRoute>} />
         </Routes>
       </Suspense>
       <ToastContainer />

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -170,7 +170,7 @@ export const ListItem = memo(function ListItem({
   const handleShare = async () => {
     haptic('light');
     
-    const listUrl = `${window.location.origin}/app/${item.listId}`;
+    const listUrl = `${window.location.origin}/d/${item.listId}`;
     const listName = "My List"; // We don't have the list name here, so use a generic name
     
     try {

--- a/src/pages/InviteLanding.tsx
+++ b/src/pages/InviteLanding.tsx
@@ -24,7 +24,7 @@ export function InviteLanding() {
 
     if (isAuthenticated) {
       // Already logged in — go to app (redemption happens via ReferralRedeemer)
-      navigate("/app", { replace: true });
+      navigate("/d", { replace: true });
     } else {
       navigate("/login", { replace: true });
     }

--- a/src/pages/ListView.tsx
+++ b/src/pages/ListView.tsx
@@ -401,7 +401,7 @@ export function ListView() {
   const handleNativeShare = useCallback(async () => {
     if (!list) return;
     
-    const listUrl = `${window.location.origin}/app/${list._id}`;
+    const listUrl = `${window.location.origin}/d/${list._id}`;
     
     try {
       await shareList(list.name, listUrl);
@@ -627,7 +627,7 @@ export function ListView() {
           This list may have been deleted or you don't have access.
         </p>
         <Link 
-          to="/app" 
+          to="/d"
           className="inline-flex items-center gap-2 px-6 py-3 bg-amber-500 hover:bg-amber-600 text-white rounded-xl font-semibold transition-colors"
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -655,7 +655,7 @@ export function ListView() {
           This list is not shared. Ask the owner to publish it.
         </p>
         <Link 
-          to="/app" 
+          to="/d"
           className="inline-flex items-center gap-2 px-6 py-3 bg-amber-500 hover:bg-amber-600 text-white rounded-xl font-semibold transition-colors"
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -686,7 +686,7 @@ export function ListView() {
         <div className="flex items-start gap-3">
           {/* Back button */}
           <Link
-            to="/app"
+            to="/d"
             onClick={() => haptic('light')}
             className="flex-shrink-0 w-10 h-10 flex items-center justify-center text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-xl transition-colors"
             aria-label="Back to lists"
@@ -1274,7 +1274,7 @@ export function ListView() {
           <DeleteListDialog
             list={list}
             onClose={() => setIsDeleteDialogOpen(false)}
-            onDeleted={() => navigate("/app")}
+            onDeleted={() => navigate("/d")}
           />
         )}
 

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -41,7 +41,7 @@ export function Login({ embedded = false }: LoginProps) {
 
   // Redirect if already authenticated (unless embedded)
   if (isAuthenticated && !embedded) {
-    navigate("/app", { replace: true });
+    navigate("/d", { replace: true });
     return null;
   }
 
@@ -87,7 +87,7 @@ export function Login({ embedded = false }: LoginProps) {
       // On successful verification, useAuth will update isAuthenticated
       // If not embedded, redirect to app; if embedded, parent handles navigation
       if (!embedded) {
-        navigate("/app", { replace: true });
+        navigate("/d", { replace: true });
       }
     } catch (err) {
       console.error("Failed to verify OTP:", err);

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -55,7 +55,7 @@ export function Pricing() {
         },
         body: JSON.stringify({
           priceId,
-          successUrl: `${origin}/app?billing=success`,
+          successUrl: `${origin}/d?billing=success`,
           cancelUrl: `${origin}/pricing`,
         }),
       });
@@ -284,7 +284,7 @@ export function Pricing() {
       {/* Back link */}
       <div className="mt-10 text-center">
         <Link
-          to="/app"
+          to="/d"
           className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
         >
           ← Back to app

--- a/src/pages/PriorityFocus.tsx
+++ b/src/pages/PriorityFocus.tsx
@@ -231,7 +231,7 @@ export function PriorityFocus() {
         <div>
           <div className="flex items-center gap-2">
             <Link
-              to="/app"
+              to="/d"
               onClick={() => haptic("light")}
               className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
             >

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -77,7 +77,7 @@ export function Profile() {
     <div className="max-w-2xl mx-auto">
       {/* Back button */}
       <Link
-        to="/app"
+        to="/d"
         onClick={() => haptic('light')}
         className="inline-flex items-center gap-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 mb-6 transition-colors"
       >

--- a/src/pages/Templates.tsx
+++ b/src/pages/Templates.tsx
@@ -121,7 +121,7 @@ export function Templates() {
       {/* Header */}
       <div className="flex items-center gap-3 mb-6">
         <Link
-          to="/app"
+          to="/d"
           className="p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg transition-colors"
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/workers/service-worker.ts
+++ b/src/workers/service-worker.ts
@@ -217,7 +217,7 @@ self.addEventListener('notificationclick', (event) => {
 
   const notifData = event.notification.data;
   const listId = notifData?.listId || notifData?.data?.listId;
-  const urlToOpen = notifData?.url || (listId ? `/list/${listId}` : '/app');
+  const urlToOpen = notifData?.url || (listId ? `/list/${listId}` : '/d');
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {


### PR DESCRIPTION
Shorter, brand-neutral path for the Home page. Updates:
- React Router route + all Link/Navigate targets
- Login + InviteLanding + ListView delete redirects
- Stripe checkout success URL
- Service worker notification fallback URL
- PWA manifest 'new list' shortcut
- E2E test assertions and navigation targets