### PR TITLE
Wire Cloudflare for SaaS for custom domain support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ android/build/
 app/test-results/*
 # Lighthouse CI results
 .lighthouseci/
+tmp/

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -22,6 +22,7 @@ import type * as billingHttp from "../billingHttp.js";
 import type * as bitcoinAnchors from "../bitcoinAnchors.js";
 import type * as categories from "../categories.js";
 import type * as categoriesHttp from "../categoriesHttp.js";
+import type * as cloudflare from "../cloudflare.js";
 import type * as comments from "../comments.js";
 import type * as didCreation from "../didCreation.js";
 import type * as didLogs from "../didLogs.js";
@@ -81,6 +82,7 @@ declare const fullApi: ApiFromModules<{
   bitcoinAnchors: typeof bitcoinAnchors;
   categories: typeof categories;
   categoriesHttp: typeof categoriesHttp;
+  cloudflare: typeof cloudflare;
   comments: typeof comments;
   didCreation: typeof didCreation;
   didLogs: typeof didLogs;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -24,6 +24,7 @@ import type * as categories from "../categories.js";
 import type * as categoriesHttp from "../categoriesHttp.js";
 import type * as cloudflare from "../cloudflare.js";
 import type * as comments from "../comments.js";
+import type * as crons from "../crons.js";
 import type * as didCreation from "../didCreation.js";
 import type * as didLogs from "../didLogs.js";
 import type * as didLogsHttp from "../didLogsHttp.js";
@@ -84,6 +85,7 @@ declare const fullApi: ApiFromModules<{
   categoriesHttp: typeof categoriesHttp;
   cloudflare: typeof cloudflare;
   comments: typeof comments;
+  crons: typeof crons;
   didCreation: typeof didCreation;
   didLogs: typeof didLogs;
   didLogsHttp: typeof didLogsHttp;

--- a/convex/cloudflare.ts
+++ b/convex/cloudflare.ts
@@ -1,0 +1,90 @@
+// Pure REST client for Cloudflare's Custom Hostnames API.
+// No Convex types — only plain values. Easy to unit-test by stubbing globalThis.fetch.
+
+const API_BASE = "https://api.cloudflare.com/client/v4";
+
+export interface CustomHostnameRecord {
+  id: string;
+  hostname: string;
+  status: "pending" | "active" | "blocked" | "moved" | "deleted";
+  ssl: {
+    status:
+      | "initializing"
+      | "pending_validation"
+      | "pending_issuance"
+      | "pending_deployment"
+      | "active"
+      | "expired"
+      | "deleted";
+  };
+  verification_errors?: string[];
+}
+
+interface CfResponse<T> {
+  success: boolean;
+  errors?: Array<{ code: number; message: string }>;
+  result?: T;
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is not set`);
+  return value;
+}
+
+async function cfFetch<T>(
+  path: string,
+  init: RequestInit = {}
+): Promise<T | undefined> {
+  const token = requireEnv("CLOUDFLARE_API_TOKEN");
+  const zone = requireEnv("CLOUDFLARE_ZONE_ID");
+  const url = `${API_BASE}/zones/${zone}${path}`;
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      ...(init.headers ?? {}),
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+  const payload = (await response.json()) as CfResponse<T>;
+  if (!response.ok || !payload.success) {
+    const messages = (payload.errors ?? [])
+      .map((e) => e.message)
+      .filter(Boolean)
+      .join("; ");
+    throw new Error(
+      messages || `Cloudflare API ${response.status} ${response.statusText}`
+    );
+  }
+  return payload.result;
+}
+
+export async function createCustomHostname(
+  hostname: string
+): Promise<CustomHostnameRecord> {
+  const result = await cfFetch<CustomHostnameRecord>("/custom_hostnames", {
+    method: "POST",
+    body: JSON.stringify({
+      hostname,
+      ssl: { method: "http", type: "dv" },
+    }),
+  });
+  if (!result) throw new Error("Cloudflare returned no result for createCustomHostname");
+  return result;
+}
+
+export async function getCustomHostname(
+  id: string
+): Promise<CustomHostnameRecord> {
+  const result = await cfFetch<CustomHostnameRecord>(
+    `/custom_hostnames/${id}`,
+    { method: "GET" }
+  );
+  if (!result) throw new Error("Cloudflare returned no result for getCustomHostname");
+  return result;
+}
+
+export async function deleteCustomHostname(id: string): Promise<void> {
+  await cfFetch<unknown>(`/custom_hostnames/${id}`, { method: "DELETE" });
+}

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,0 +1,12 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+crons.interval(
+  "poll custom hostnames",
+  { seconds: 60 },
+  internal.siteActions.pollPendingCustomHostnames
+);
+
+export default crons;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -327,6 +327,26 @@ export default defineSchema({
     redirectTo: v.optional(v.string()),
     createdAt: v.number(),
     updatedAt: v.number(),
+    // Cloudflare-tracked fields (custom hostnames only)
+    cfHostnameId: v.optional(v.string()),
+    cfStatus: v.optional(v.union(
+      v.literal("pending"),
+      v.literal("active"),
+      v.literal("blocked"),
+      v.literal("moved"),
+      v.literal("deleted"),
+    )),
+    cfSslStatus: v.optional(v.union(
+      v.literal("initializing"),
+      v.literal("pending_validation"),
+      v.literal("pending_issuance"),
+      v.literal("pending_deployment"),
+      v.literal("active"),
+      v.literal("expired"),
+      v.literal("deleted"),
+    )),
+    verificationErrors: v.optional(v.array(v.string())),
+    lastCheckedAt: v.optional(v.number()),
   })
     .index("by_site", ["siteId"])
     .index("by_hostname", ["hostname"])

--- a/convex/siteActions.ts
+++ b/convex/siteActions.ts
@@ -1,10 +1,10 @@
 "use node";
 
-import { action } from "./_generated/server";
-import { internal } from "./_generated/api";
+import { action, internalAction } from "./_generated/server";
+import { internal, api } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { v } from "convex/values";
-import { createCustomHostname } from "./cloudflare";
+import { createCustomHostname, getCustomHostname } from "./cloudflare";
 import { createHash, createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 import { sha512 } from "@noble/hashes/sha2.js";
 import { concatBytes, bytesToHex } from "@noble/hashes/utils.js";
@@ -434,5 +434,95 @@ export const requestCustomHostname = action({
     );
 
     return { hostnameId, cfHostnameId: cfRecord.id };
+  },
+});
+
+const PENDING_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export const pollCustomHostname = internalAction({
+  args: { hostnameId: v.id("siteHostnames") },
+  handler: async (ctx, args): Promise<void> => {
+    const row = await ctx.runQuery(internal.siteInternals.getHostname, {
+      hostnameId: args.hostnameId,
+    });
+    if (!row || row.kind !== "custom" || !row.cfHostnameId || row.status === "active") {
+      return;
+    }
+
+    let cfRecord;
+    try {
+      cfRecord = await getCustomHostname(row.cfHostnameId);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Cloudflare poll failed";
+      await ctx.runMutation(internal.siteInternals.updateHostnameVerification, {
+        hostnameId: args.hostnameId,
+        cfStatus: row.cfStatus ?? "pending",
+        cfSslStatus: row.cfSslStatus ?? "initializing",
+        verificationErrors: [message],
+        now: Date.now(),
+      });
+      return;
+    }
+
+    const now = Date.now();
+    const errors: string[] = [];
+    if (cfRecord.verification_errors && cfRecord.verification_errors.length > 0) {
+      errors.push(...cfRecord.verification_errors);
+    }
+    if (
+      cfRecord.status === "pending" &&
+      now - row.createdAt > PENDING_TIMEOUT_MS
+    ) {
+      errors.push(
+        `Timed out waiting for DNS verification. Check the CNAME at ${row.hostname}.`
+      );
+    }
+
+    await ctx.runMutation(internal.siteInternals.updateHostnameVerification, {
+      hostnameId: args.hostnameId,
+      cfStatus: cfRecord.status,
+      cfSslStatus: cfRecord.ssl.status,
+      verificationErrors: errors,
+      now,
+    });
+
+    const verified = cfRecord.status === "active" && cfRecord.ssl.status === "active";
+    if (verified && row.status === "pending") {
+      const owner = await ctx.runQuery(internal.siteInternals.getSiteOwner, {
+        siteId: row.siteId,
+      });
+      if (!owner) return;
+      try {
+        await ctx.runAction(api.siteActions.migrateVerifiedCustomDomain, {
+          ownerDid: owner.ownerDid,
+          siteId: row.siteId,
+          hostname: row.hostname,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "DID migration failed";
+        await ctx.runMutation(internal.siteInternals.updateHostnameVerification, {
+          hostnameId: args.hostnameId,
+          cfStatus: cfRecord.status,
+          cfSslStatus: cfRecord.ssl.status,
+          verificationErrors: [...errors, message],
+          now: Date.now(),
+        });
+      }
+    }
+  },
+});
+
+export const pollPendingCustomHostnames = internalAction({
+  args: {},
+  handler: async (ctx): Promise<void> => {
+    const rows = await ctx.runQuery(
+      internal.siteInternals.listPendingCustomHostnames,
+      {}
+    );
+    for (const row of rows) {
+      await ctx.scheduler.runAfter(0, internal.siteActions.pollCustomHostname, {
+        hostnameId: row._id,
+      });
+    }
   },
 });

--- a/convex/siteActions.ts
+++ b/convex/siteActions.ts
@@ -2,7 +2,9 @@
 
 import { action } from "./_generated/server";
 import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
 import { v } from "convex/values";
+import { createCustomHostname } from "./cloudflare";
 import { createHash, createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
 import { sha512 } from "@noble/hashes/sha2.js";
 import { concatBytes, bytesToHex } from "@noble/hashes/utils.js";
@@ -389,5 +391,48 @@ export const migrateVerifiedCustomDomain = action({
       did: migrated.did,
       scid: record.site.scid,
     };
+  },
+});
+
+function normalizeRequestedHostname(input: string): string {
+  const lowered = input.trim().toLowerCase().replace(/\.$/, "");
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/.test(lowered)) {
+    throw new Error("That doesn't look like a valid hostname. Try something like www.example.com.");
+  }
+  return lowered;
+}
+
+export const requestCustomHostname = action({
+  args: {
+    ownerDid: v.string(),
+    siteId: v.id("sites"),
+    hostname: v.string(),
+  },
+  handler: async (ctx, args): Promise<{ hostnameId: Id<"siteHostnames">; cfHostnameId: string }> => {
+    const hostname = normalizeRequestedHostname(args.hostname);
+
+    const record = await ctx.runQuery(
+      internal.siteInternals.getSiteIdentityForUpdate,
+      { siteId: args.siteId, ownerDid: args.ownerDid }
+    );
+    if (!record) {
+      throw new Error("Site not found");
+    }
+
+    const cfRecord = await createCustomHostname(hostname);
+
+    const hostnameId: Id<"siteHostnames"> = await ctx.runMutation(
+      internal.siteInternals.recordCustomHostnameRequest,
+      {
+        siteId: args.siteId,
+        hostname,
+        cfHostnameId: cfRecord.id,
+        cfStatus: cfRecord.status,
+        cfSslStatus: cfRecord.ssl.status,
+        now: Date.now(),
+      }
+    );
+
+    return { hostnameId, cfHostnameId: cfRecord.id };
   },
 });

--- a/convex/siteInternals.ts
+++ b/convex/siteInternals.ts
@@ -210,3 +210,106 @@ export const applyDomainMigration = internalMutation({
     return { siteId: args.siteId, hostnameId: customHostnameId };
   },
 });
+
+export const recordCustomHostnameRequest = internalMutation({
+  args: {
+    siteId: v.id("sites"),
+    hostname: v.string(),
+    cfHostnameId: v.string(),
+    cfStatus: v.union(
+      v.literal("pending"),
+      v.literal("active"),
+      v.literal("blocked"),
+      v.literal("moved"),
+      v.literal("deleted"),
+    ),
+    cfSslStatus: v.union(
+      v.literal("initializing"),
+      v.literal("pending_validation"),
+      v.literal("pending_issuance"),
+      v.literal("pending_deployment"),
+      v.literal("active"),
+      v.literal("expired"),
+      v.literal("deleted"),
+    ),
+    now: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db
+      .query("siteHostnames")
+      .withIndex("by_hostname", (q) => q.eq("hostname", args.hostname))
+      .first();
+    if (existing) {
+      throw new Error("That domain is already connected to another boop site.");
+    }
+    const id = await ctx.db.insert("siteHostnames", {
+      siteId: args.siteId,
+      hostname: args.hostname,
+      kind: "custom",
+      status: "pending",
+      isPrimary: false,
+      cfHostnameId: args.cfHostnameId,
+      cfStatus: args.cfStatus,
+      cfSslStatus: args.cfSslStatus,
+      verificationErrors: [],
+      lastCheckedAt: args.now,
+      createdAt: args.now,
+      updatedAt: args.now,
+    });
+    return id;
+  },
+});
+
+export const updateHostnameVerification = internalMutation({
+  args: {
+    hostnameId: v.id("siteHostnames"),
+    cfStatus: v.union(
+      v.literal("pending"),
+      v.literal("active"),
+      v.literal("blocked"),
+      v.literal("moved"),
+      v.literal("deleted"),
+    ),
+    cfSslStatus: v.union(
+      v.literal("initializing"),
+      v.literal("pending_validation"),
+      v.literal("pending_issuance"),
+      v.literal("pending_deployment"),
+      v.literal("active"),
+      v.literal("expired"),
+      v.literal("deleted"),
+    ),
+    verificationErrors: v.array(v.string()),
+    now: v.number(),
+  },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.hostnameId, {
+      cfStatus: args.cfStatus,
+      cfSslStatus: args.cfSslStatus,
+      verificationErrors: args.verificationErrors,
+      lastCheckedAt: args.now,
+      updatedAt: args.now,
+    });
+  },
+});
+
+export const listPendingCustomHostnames = internalQuery({
+  args: {},
+  handler: async (ctx) => {
+    const all = await ctx.db.query("siteHostnames").collect();
+    return all.filter(
+      (h) =>
+        h.kind === "custom" &&
+        h.status === "pending" &&
+        h.cfHostnameId !== undefined &&
+        (h.verificationErrors === undefined || h.verificationErrors.length === 0),
+    );
+  },
+});
+
+export const getHostname = internalQuery({
+  args: { hostnameId: v.id("siteHostnames") },
+  handler: async (ctx, args) => {
+    return ctx.db.get(args.hostnameId);
+  },
+});

--- a/convex/siteInternals.ts
+++ b/convex/siteInternals.ts
@@ -313,3 +313,11 @@ export const getHostname = internalQuery({
     return ctx.db.get(args.hostnameId);
   },
 });
+
+export const getSiteOwner = internalQuery({
+  args: { siteId: v.id("sites") },
+  handler: async (ctx, args) => {
+    const site = await ctx.db.get(args.siteId);
+    return site ? { ownerDid: site.ownerDid } : null;
+  },
+});

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -134,9 +134,10 @@ Cloudflare for SaaS is now wired through `convex/cloudflare.ts` + `convex/siteAc
 
 2. **Set the fallback origin to `boop.ad`.** In the Custom Hostnames settings, set "Fallback Origin" to `boop.ad`. Customer-domain traffic flows: customer → CF edge (TLS terminated with the per-hostname cert) → CF proxies to `boop.ad` (the existing Railway domain) with the original Host header preserved → `server.ts` Host-header-routes to `serveHostedSite()`.
 
-3. **Generate an API token.** Cloudflare dashboard → My Profile → API Tokens → Create Token. Custom token with these permissions, scoped to the `boop.ad` zone:
+3. **Generate an API token.** Cloudflare dashboard → My Profile → API Tokens → Create Custom Token. The token only needs one permission, scoped to the `boop.ad` zone:
    - `Zone:SSL and Certificates:Edit`
-   - `Zone:Custom Hostnames:Edit`
+
+   The Custom Hostnames API endpoints are gated by this scope — there is no separate "Custom Hostnames" permission. `Zone:Zone:Read` is auto-included by Cloudflare when you save a zone-scoped token.
 
 4. **Set Convex env vars.**
    ```bash

--- a/docs/deployment-runbook.md
+++ b/docs/deployment-runbook.md
@@ -128,14 +128,26 @@ These are read by `server.ts`, which replaces static `serve dist -s` when Sites 
 
 ### Cloudflare for SaaS setup
 
-No Cloudflare for SaaS configuration was found in this repo during the Sites discovery pass. Before the custom-domain wizard can complete end-to-end, configure:
+Cloudflare for SaaS is now wired through `convex/cloudflare.ts` + `convex/siteActions.ts`. To enable in production:
 
-- Wildcard DNS for `*.boop.ad` pointing at the Railway service through Cloudflare.
-- A CNAME target owned by boop, such as `sites.boop.ad`.
-- Cloudflare Custom Hostnames API credentials (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ZONE_ID`).
-- Fallback origin for custom hostnames.
+1. **Enable Cloudflare for SaaS on the `boop.ad` zone.** Cloudflare dashboard → boop.ad → SSL/TLS → Custom Hostnames. The product is available on every Cloudflare plan including Free; the first 100 hostnames are included, then $0.10/hostname/month up to 50,000.
 
-Until that exists, the wizard should show CNAME instructions but remain in a "waiting on setup" state. Apex domains should default to `www.` as primary, with separate apex redirect instructions at the registrar unless the current Cloudflare plan clearly supports apex custom hostnames.
+2. **Set the fallback origin to `boop.ad`.** In the Custom Hostnames settings, set "Fallback Origin" to `boop.ad`. Customer-domain traffic flows: customer → CF edge (TLS terminated with the per-hostname cert) → CF proxies to `boop.ad` (the existing Railway domain) with the original Host header preserved → `server.ts` Host-header-routes to `serveHostedSite()`.
+
+3. **Generate an API token.** Cloudflare dashboard → My Profile → API Tokens → Create Token. Custom token with these permissions, scoped to the `boop.ad` zone:
+   - `Zone:SSL and Certificates:Edit`
+   - `Zone:Custom Hostnames:Edit`
+
+4. **Set Convex env vars.**
+   ```bash
+   npx convex env set CLOUDFLARE_API_TOKEN "<token>"
+   npx convex env set CLOUDFLARE_ZONE_ID "<zone-id>"
+   ```
+   The zone ID is shown on the boop.ad zone overview page in the Cloudflare dashboard, right side panel.
+
+5. **Confirm `VITE_CUSTOM_DOMAIN_CNAME_TARGET` is set.** This is what the modal shows users as the CNAME target. Should be `boop.ad`. Set in Railway service env.
+
+The 60-second `pollPendingCustomHostnames` cron picks up new hostnames and walks them from `pending_dns` → `pending_ssl` → `active`, then triggers the WebVH migration automatically.
 
 ### CI/CD (GitHub Actions / Railway build)
 

--- a/scripts/cloudflare.test.mjs
+++ b/scripts/cloudflare.test.mjs
@@ -1,0 +1,174 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, rm } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+import { build } from "esbuild";
+
+const outdir = "tmp/cloudflare-test";
+
+async function loadCloudflareModule(env = {}) {
+  await rm(outdir, { recursive: true, force: true });
+  await mkdir(outdir, { recursive: true });
+  await build({
+    entryPoints: ["./convex/cloudflare.ts"],
+    outfile: `${outdir}/cloudflare.mjs`,
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    target: "node20",
+    external: ["convex/*"],
+  });
+  for (const [k, v] of Object.entries(env)) process.env[k] = v;
+  return import(
+    `${pathToFileURL(`${process.cwd()}/${outdir}/cloudflare.mjs`).href}?t=${Date.now()}`
+  );
+}
+
+function stubFetch(handler) {
+  const calls = [];
+  globalThis.fetch = async (url, init = {}) => {
+    calls.push({ url, init });
+    return handler(url, init, calls.length);
+  };
+  return calls;
+}
+
+const TOKEN = "test-token";
+const ZONE = "test-zone-id";
+
+test("createCustomHostname posts to the right URL with the right body", async () => {
+  const cf = await loadCloudflareModule({
+    CLOUDFLARE_API_TOKEN: TOKEN,
+    CLOUDFLARE_ZONE_ID: ZONE,
+  });
+  const calls = stubFetch(async () =>
+    new Response(
+      JSON.stringify({
+        success: true,
+        result: {
+          id: "ch_abc",
+          hostname: "www.forexample.com",
+          status: "pending",
+          ssl: { status: "initializing" },
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    )
+  );
+
+  const result = await cf.createCustomHostname("www.forexample.com");
+
+  assert.equal(calls.length, 1);
+  assert.equal(
+    calls[0].url,
+    `https://api.cloudflare.com/client/v4/zones/${ZONE}/custom_hostnames`
+  );
+  assert.equal(calls[0].init.method, "POST");
+  assert.equal(
+    calls[0].init.headers.Authorization,
+    `Bearer ${TOKEN}`
+  );
+  const body = JSON.parse(calls[0].init.body);
+  assert.equal(body.hostname, "www.forexample.com");
+  assert.deepEqual(body.ssl, { method: "http", type: "dv" });
+  assert.equal(result.id, "ch_abc");
+  assert.equal(result.status, "pending");
+  assert.equal(result.ssl.status, "initializing");
+});
+
+test("getCustomHostname GETs the hostname and returns the parsed record", async () => {
+  const cf = await loadCloudflareModule({
+    CLOUDFLARE_API_TOKEN: TOKEN,
+    CLOUDFLARE_ZONE_ID: ZONE,
+  });
+  const calls = stubFetch(async () =>
+    new Response(
+      JSON.stringify({
+        success: true,
+        result: {
+          id: "ch_abc",
+          hostname: "www.forexample.com",
+          status: "active",
+          ssl: { status: "active" },
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    )
+  );
+
+  const result = await cf.getCustomHostname("ch_abc");
+
+  assert.equal(calls.length, 1);
+  assert.equal(
+    calls[0].url,
+    `https://api.cloudflare.com/client/v4/zones/${ZONE}/custom_hostnames/ch_abc`
+  );
+  assert.equal(calls[0].init.method, "GET");
+  assert.equal(result.status, "active");
+  assert.equal(result.ssl.status, "active");
+});
+
+test("deleteCustomHostname DELETEs and returns void", async () => {
+  const cf = await loadCloudflareModule({
+    CLOUDFLARE_API_TOKEN: TOKEN,
+    CLOUDFLARE_ZONE_ID: ZONE,
+  });
+  const calls = stubFetch(async () =>
+    new Response(
+      JSON.stringify({ success: true, result: { id: "ch_abc" } }),
+      { status: 200, headers: { "Content-Type": "application/json" } }
+    )
+  );
+
+  const result = await cf.deleteCustomHostname("ch_abc");
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].init.method, "DELETE");
+  assert.equal(result, undefined);
+});
+
+test("missing CLOUDFLARE_API_TOKEN throws a clear error", async () => {
+  delete process.env.CLOUDFLARE_API_TOKEN;
+  process.env.CLOUDFLARE_ZONE_ID = ZONE;
+  const cf = await loadCloudflareModule({});
+  delete process.env.CLOUDFLARE_API_TOKEN;
+  await assert.rejects(
+    () => cf.createCustomHostname("www.forexample.com"),
+    /CLOUDFLARE_API_TOKEN is not set/
+  );
+});
+
+test("missing CLOUDFLARE_ZONE_ID throws a clear error", async () => {
+  delete process.env.CLOUDFLARE_ZONE_ID;
+  process.env.CLOUDFLARE_API_TOKEN = TOKEN;
+  const cf = await loadCloudflareModule({});
+  delete process.env.CLOUDFLARE_ZONE_ID;
+  await assert.rejects(
+    () => cf.createCustomHostname("www.forexample.com"),
+    /CLOUDFLARE_ZONE_ID is not set/
+  );
+});
+
+test("4xx response surfaces as Error with joined CF errors", async () => {
+  const cf = await loadCloudflareModule({
+    CLOUDFLARE_API_TOKEN: TOKEN,
+    CLOUDFLARE_ZONE_ID: ZONE,
+  });
+  stubFetch(async () =>
+    new Response(
+      JSON.stringify({
+        success: false,
+        errors: [
+          { code: 1414, message: "hostname is invalid" },
+          { code: 1500, message: "zone limit reached" },
+        ],
+      }),
+      { status: 400, headers: { "Content-Type": "application/json" } }
+    )
+  );
+
+  await assert.rejects(
+    () => cf.createCustomHostname("not-a-real-hostname"),
+    /hostname is invalid.*zone limit reached/
+  );
+});

--- a/src/components/sites/ConnectDomainModal.tsx
+++ b/src/components/sites/ConnectDomainModal.tsx
@@ -1,18 +1,56 @@
 import { useState, type FormEvent } from "react";
+import { useAction, useQuery } from "convex/react";
+import { api } from "../../../convex/_generated/api";
+import type { Id } from "../../../convex/_generated/dataModel";
 
 interface ConnectDomainModalProps {
-  hostname: string;
+  siteId: Id<"sites">;
+  ownerDid: string;
+  hostname: string; // boop subdomain shown for context
   onClose: () => void;
 }
 
-export function ConnectDomainModal({ hostname, onClose }: ConnectDomainModalProps) {
+type Phase =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "pending_dns" }
+  | { kind: "pending_ssl" }
+  | { kind: "active"; hostname: string }
+  | { kind: "failed"; errors: string[] };
+
+export function ConnectDomainModal({
+  siteId,
+  ownerDid,
+  hostname,
+  onClose,
+}: ConnectDomainModalProps) {
   const [domain, setDomain] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
   const cnameTarget =
     (import.meta.env.VITE_CUSTOM_DOMAIN_CNAME_TARGET as string | undefined) ||
-    "sites.boop.ad";
+    "boop.ad";
 
-  const handleSubmit = (event: FormEvent) => {
+  const requestCustomHostname = useAction(api.siteActions.requestCustomHostname);
+  const site = useQuery(api.sites.getSite, { siteId, ownerDid });
+  const customRow = site?.hostnames.find((h) => h.kind === "custom");
+
+  const phase = derivePhase(customRow, submitting);
+
+  const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
+    if (!domain.trim()) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      await requestCustomHostname({ ownerDid, siteId, hostname: domain });
+      setDomain("");
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : "Something went wrong.");
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -39,59 +77,233 @@ export function ConnectDomainModal({ hostname, onClose }: ConnectDomainModalProp
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="p-5 space-y-5">
-          <div>
-            <label htmlFor="site-domain" className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
-              Domain
-            </label>
-            <input
-              id="site-domain"
-              value={domain}
-              onChange={(event) => setDomain(event.target.value)}
-              placeholder="www.forexample.com"
-              className="w-full rounded-xl border-2 border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-950 px-4 py-3 text-stone-900 dark:text-stone-100 focus:outline-none focus:border-amber-500"
+        <div className="p-5 space-y-5">
+          {phase.kind === "idle" && (
+            <IdleForm
+              domain={domain}
+              setDomain={setDomain}
+              cnameTarget={cnameTarget}
+              onSubmit={handleSubmit}
+              submitError={submitError}
+              onClose={onClose}
             />
-          </div>
-
-          <div className="rounded-xl bg-stone-50 dark:bg-gray-950 border border-stone-200 dark:border-gray-800 p-4 space-y-3">
-            <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-stone-500 dark:text-stone-400">
-                DNS instructions
-              </p>
-              <p className="mt-1 text-sm text-stone-700 dark:text-stone-300">
-                Add a CNAME record pointing your domain to:
-              </p>
-            </div>
-            <code className="block rounded-lg bg-white dark:bg-gray-900 border border-stone-200 dark:border-gray-800 px-3 py-2 text-sm text-stone-900 dark:text-stone-100 break-all">
-              {cnameTarget}
-            </code>
+          )}
+          {phase.kind === "submitting" && <SubmittingPanel />}
+          {phase.kind === "pending_dns" && customRow && (
+            <PendingDnsPanel hostname={customRow.hostname} cnameTarget={cnameTarget} onClose={onClose} />
+          )}
+          {phase.kind === "pending_ssl" && customRow && (
+            <PendingSslPanel hostname={customRow.hostname} onClose={onClose} />
+          )}
+          {phase.kind === "active" && (
+            <ActivePanel hostname={phase.hostname} onClose={onClose} />
+          )}
+          {phase.kind === "failed" && customRow && (
+            <FailedPanel errors={phase.errors} hostname={customRow.hostname} onClose={onClose} />
+          )}
+          {phase.kind !== "active" && (
             <p className="text-xs text-stone-500 dark:text-stone-400">
-              Apex domains are fussy on some Cloudflare plans. Start with <code>www</code>; set up an apex redirect after that.
+              boop link <strong>{hostname}</strong> stays available the whole time.
             </p>
-          </div>
-
-          <div className="rounded-xl bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 p-4 text-sm text-amber-800 dark:text-amber-200">
-            Cloudflare for SaaS is not configured in this repo yet. The next step is to wire the Custom Hostnames API, then boop can poll DNS and move this site from <strong>{hostname}</strong> to your domain without changing its identity.
-          </div>
-
-          <div className="flex gap-3">
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex-1 rounded-xl bg-stone-100 dark:bg-gray-800 px-4 py-3 text-sm font-semibold text-stone-700 dark:text-stone-200"
-            >
-              Not now
-            </button>
-            <button
-              type="submit"
-              disabled
-              className="flex-1 rounded-xl bg-amber-500 px-4 py-3 text-sm font-semibold text-white opacity-60"
-            >
-              Waiting on setup
-            </button>
-          </div>
-        </form>
+          )}
+        </div>
       </div>
+    </div>
+  );
+}
+
+function derivePhase(
+  row:
+    | {
+        status: string;
+        hostname: string;
+        cfStatus?: string;
+        cfSslStatus?: string;
+        verificationErrors?: string[];
+      }
+    | undefined,
+  submitting: boolean
+): Phase {
+  if (submitting) return { kind: "submitting" };
+  if (!row) return { kind: "idle" };
+  if (row.verificationErrors && row.verificationErrors.length > 0) {
+    return { kind: "failed", errors: row.verificationErrors };
+  }
+  if (row.status === "active") {
+    return { kind: "active", hostname: row.hostname };
+  }
+  if (row.cfStatus === "active" && row.cfSslStatus !== "active") {
+    return { kind: "pending_ssl" };
+  }
+  return { kind: "pending_dns" };
+}
+
+function IdleForm({
+  domain,
+  setDomain,
+  cnameTarget,
+  onSubmit,
+  submitError,
+  onClose,
+}: {
+  domain: string;
+  setDomain: (v: string) => void;
+  cnameTarget: string;
+  onSubmit: (e: FormEvent) => void;
+  submitError: string | null;
+  onClose: () => void;
+}) {
+  return (
+    <form onSubmit={onSubmit} className="space-y-5">
+      <div>
+        <label htmlFor="site-domain" className="block text-sm font-medium text-stone-700 dark:text-stone-300 mb-2">
+          Domain
+        </label>
+        <input
+          id="site-domain"
+          value={domain}
+          onChange={(event) => setDomain(event.target.value)}
+          placeholder="www.forexample.com"
+          className="w-full rounded-xl border-2 border-stone-200 dark:border-gray-700 bg-stone-50 dark:bg-gray-950 px-4 py-3 text-stone-900 dark:text-stone-100 focus:outline-none focus:border-amber-500"
+        />
+      </div>
+      <div className="rounded-xl bg-stone-50 dark:bg-gray-950 border border-stone-200 dark:border-gray-800 p-4 space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-stone-500 dark:text-stone-400">
+          DNS instructions
+        </p>
+        <p className="mt-1 text-sm text-stone-700 dark:text-stone-300">
+          Add a CNAME record pointing your domain to:
+        </p>
+        <code className="block rounded-lg bg-white dark:bg-gray-900 border border-stone-200 dark:border-gray-800 px-3 py-2 text-sm text-stone-900 dark:text-stone-100 break-all">
+          {cnameTarget}
+        </code>
+        <p className="text-xs text-stone-500 dark:text-stone-400">
+          Apex domains are fussy on some DNS hosts. Start with <code>www</code>; set up an apex redirect after that.
+        </p>
+      </div>
+      {submitError && (
+        <div className="rounded-xl bg-rose-50 dark:bg-rose-950/30 border border-rose-200 dark:border-rose-800 p-3 text-sm text-rose-800 dark:text-rose-200">
+          {submitError}
+        </div>
+      )}
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex-1 rounded-xl bg-stone-100 dark:bg-gray-800 px-4 py-3 text-sm font-semibold text-stone-700 dark:text-stone-200"
+        >
+          Not now
+        </button>
+        <button
+          type="submit"
+          disabled={!domain.trim()}
+          className="flex-1 rounded-xl bg-amber-500 px-4 py-3 text-sm font-semibold text-white disabled:opacity-60"
+        >
+          Connect
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function SubmittingPanel() {
+  return (
+    <div className="rounded-xl bg-stone-50 dark:bg-gray-950 border border-stone-200 dark:border-gray-800 p-4 text-sm text-stone-700 dark:text-stone-200">
+      Registering your domain…
+    </div>
+  );
+}
+
+function PendingDnsPanel({
+  hostname,
+  cnameTarget,
+  onClose,
+}: {
+  hostname: string;
+  cnameTarget: string;
+  onClose: () => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl bg-stone-50 dark:bg-gray-950 border border-stone-200 dark:border-gray-800 p-4 space-y-2 text-sm text-stone-700 dark:text-stone-200">
+        <p>
+          Waiting for the CNAME at <strong>{hostname}</strong> to point at <code>{cnameTarget}</code>.
+        </p>
+        <p className="text-xs text-stone-500 dark:text-stone-400">
+          This usually takes a few minutes after you add the record. We'll keep checking automatically.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        className="w-full rounded-xl bg-stone-100 dark:bg-gray-800 px-4 py-3 text-sm font-semibold text-stone-700 dark:text-stone-200"
+      >
+        Close
+      </button>
+    </div>
+  );
+}
+
+function PendingSslPanel({ hostname, onClose }: { hostname: string; onClose: () => void }) {
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl bg-stone-50 dark:bg-gray-950 border border-stone-200 dark:border-gray-800 p-4 text-sm text-stone-700 dark:text-stone-200">
+        DNS verified for <strong>{hostname}</strong>. Issuing SSL certificate…
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        className="w-full rounded-xl bg-stone-100 dark:bg-gray-800 px-4 py-3 text-sm font-semibold text-stone-700 dark:text-stone-200"
+      >
+        Close
+      </button>
+    </div>
+  );
+}
+
+function ActivePanel({ hostname, onClose }: { hostname: string; onClose: () => void }) {
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl bg-emerald-50 dark:bg-emerald-950/30 border border-emerald-200 dark:border-emerald-800 p-4 text-sm text-emerald-800 dark:text-emerald-200">
+        Connected. Your site is live at <strong>https://{hostname}</strong>.
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        className="w-full rounded-xl bg-amber-500 px-4 py-3 text-sm font-semibold text-white"
+      >
+        Done
+      </button>
+    </div>
+  );
+}
+
+function FailedPanel({
+  errors,
+  hostname,
+  onClose,
+}: {
+  errors: string[];
+  hostname: string;
+  onClose: () => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl bg-rose-50 dark:bg-rose-950/30 border border-rose-200 dark:border-rose-800 p-4 text-sm text-rose-800 dark:text-rose-200 space-y-2">
+        <p>We hit a snag connecting <strong>{hostname}</strong>:</p>
+        <ul className="list-disc list-inside text-xs">
+          {errors.map((err, i) => (
+            <li key={i}>{err}</li>
+          ))}
+        </ul>
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        className="w-full rounded-xl bg-stone-100 dark:bg-gray-800 px-4 py-3 text-sm font-semibold text-stone-700 dark:text-stone-200"
+      >
+        Close
+      </button>
     </div>
   );
 }

--- a/src/pages/SiteDetail.tsx
+++ b/src/pages/SiteDetail.tsx
@@ -114,7 +114,12 @@ export function SiteDetail() {
       </div>
 
       {showDomainModal && (
-        <ConnectDomainModal hostname={hostname} onClose={() => setShowDomainModal(false)} />
+        <ConnectDomainModal
+          siteId={siteId as Id<"sites">}
+          ownerDid={did!}
+          hostname={hostname}
+          onClose={() => setShowDomainModal(false)}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Makes the "Connect a domain you own" flow on hosted sites functional. Boop now talks to Cloudflare's Custom Hostnames API, polls verification + SSL state every 60 seconds, and auto-fires the existing `migrateVerifiedCustomDomain` action when both go `active`.

- New `convex/cloudflare.ts` REST client (~80 LOC) with create/get/delete custom hostnames; pure module, unit-tested with 6 stub-fetch tests in `scripts/cloudflare.test.mjs`.
- New `requestCustomHostname` action validates ownership, registers with CF, and persists tracking state on the existing `siteHostnames` row.
- New `pollCustomHostname` / `pollPendingCustomHostnames` internal actions; cron in `convex/crons.ts` runs the latter every 60s.
- `siteHostnames` schema extended with five optional CF-tracking fields (`cfHostnameId`, `cfStatus`, `cfSslStatus`, `verificationErrors`, `lastCheckedAt`) — additive, no migration needed.
- `ConnectDomainModal` rewritten as a state-driven component with five live phases (`idle`, `submitting`, `pending_dns`, `pending_ssl`, `active`, `failed`) subscribed to the hostname row via `useQuery`.
- Deployment runbook updated with concrete enablement steps.

Spec: `Projects/boop/specs/2026-04-29 Cloudflare for SaaS Wiring.md`. Plan: `Projects/boop/plans/2026-04-29 Cloudflare for SaaS Wiring.md`.

## Operational steps before merge

The PR ships the code; production needs three manual steps:

1. Enable Cloudflare for SaaS on the `boop.ad` zone (free product, included on every plan).
2. Set the Custom Hostnames fallback origin to `boop.ad`.
3. Set Convex env: `CLOUDFLARE_API_TOKEN` (scoped: `Zone:SSL and Certificates:Edit` + `Zone:Custom Hostnames:Edit` on the `boop.ad` zone) and `CLOUDFLARE_ZONE_ID`.

Full instructions in `docs/deployment-runbook.md` § "Cloudflare for SaaS setup".

## Test plan

- [x] `npx tsc -b` clean
- [x] `node --test scripts/cloudflare.test.mjs scripts/sites.test.mjs` — 7/7 pass
- [x] `bun run build` succeeds
- [ ] After ops setup: connect a real test domain end-to-end, watch it move `pending_dns` → `pending_ssl` → `active`, and confirm the WebVH migration fires automatically
- [ ] Confirm that disconnecting (manually editing the row) re-shows the idle form correctly (deletion flow is out of scope for v1)

## Out of scope

- Cloudflare webhooks (60s poll is sufficient).
- Apex-domain wizardry (Business+ only on Cloudflare; modal already steers users to `www`).
- Hostname disconnect / removal flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)