### PR TITLE
Add Retry button for failed custom-hostname verifications

### DIFF
--- a/convex/siteActions.ts
+++ b/convex/siteActions.ts
@@ -526,3 +526,33 @@ export const pollPendingCustomHostnames = internalAction({
     }
   },
 });
+
+export const retryCustomHostname = action({
+  args: {
+    ownerDid: v.string(),
+    hostnameId: v.id("siteHostnames"),
+  },
+  handler: async (ctx, args): Promise<void> => {
+    const row = await ctx.runQuery(internal.siteInternals.getHostname, {
+      hostnameId: args.hostnameId,
+    });
+    if (!row) throw new Error("Hostname not found");
+
+    // Verify the caller owns the site this hostname belongs to.
+    const owner = await ctx.runQuery(internal.siteInternals.getSiteOwner, {
+      siteId: row.siteId,
+    });
+    if (!owner || owner.ownerDid !== args.ownerDid) {
+      throw new Error("Not authorized");
+    }
+
+    // Clear errors so the cron picks the row back up, and kick an immediate poll.
+    await ctx.runMutation(internal.siteInternals.clearHostnameErrors, {
+      hostnameId: args.hostnameId,
+      now: Date.now(),
+    });
+    await ctx.scheduler.runAfter(0, internal.siteActions.pollCustomHostname, {
+      hostnameId: args.hostnameId,
+    });
+  },
+});

--- a/convex/siteInternals.ts
+++ b/convex/siteInternals.ts
@@ -321,3 +321,14 @@ export const getSiteOwner = internalQuery({
     return site ? { ownerDid: site.ownerDid } : null;
   },
 });
+
+export const clearHostnameErrors = internalMutation({
+  args: { hostnameId: v.id("siteHostnames"), now: v.number() },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.hostnameId, {
+      verificationErrors: [],
+      lastCheckedAt: args.now,
+      updatedAt: args.now,
+    });
+  },
+});

--- a/src/components/sites/ConnectDomainModal.tsx
+++ b/src/components/sites/ConnectDomainModal.tsx
@@ -99,7 +99,13 @@ export function ConnectDomainModal({
             <ActivePanel hostname={phase.hostname} onClose={onClose} />
           )}
           {phase.kind === "failed" && customRow && (
-            <FailedPanel errors={phase.errors} hostname={customRow.hostname} onClose={onClose} />
+            <FailedPanel
+              errors={phase.errors}
+              hostname={customRow.hostname}
+              hostnameId={customRow._id}
+              ownerDid={ownerDid}
+              onClose={onClose}
+            />
           )}
           {phase.kind !== "active" && (
             <p className="text-xs text-stone-500 dark:text-stone-400">
@@ -281,12 +287,32 @@ function ActivePanel({ hostname, onClose }: { hostname: string; onClose: () => v
 function FailedPanel({
   errors,
   hostname,
+  hostnameId,
+  ownerDid,
   onClose,
 }: {
   errors: string[];
   hostname: string;
+  hostnameId: Id<"siteHostnames">;
+  ownerDid: string;
   onClose: () => void;
 }) {
+  const retry = useAction(api.siteActions.retryCustomHostname);
+  const [retrying, setRetrying] = useState(false);
+  const [retryError, setRetryError] = useState<string | null>(null);
+
+  const handleRetry = async () => {
+    setRetrying(true);
+    setRetryError(null);
+    try {
+      await retry({ ownerDid, hostnameId });
+    } catch (error) {
+      setRetryError(error instanceof Error ? error.message : "Retry failed.");
+    } finally {
+      setRetrying(false);
+    }
+  };
+
   return (
     <div className="space-y-4">
       <div className="rounded-xl bg-rose-50 dark:bg-rose-950/30 border border-rose-200 dark:border-rose-800 p-4 text-sm text-rose-800 dark:text-rose-200 space-y-2">
@@ -297,13 +323,28 @@ function FailedPanel({
           ))}
         </ul>
       </div>
-      <button
-        type="button"
-        onClick={onClose}
-        className="w-full rounded-xl bg-stone-100 dark:bg-gray-800 px-4 py-3 text-sm font-semibold text-stone-700 dark:text-stone-200"
-      >
-        Close
-      </button>
+      {retryError && (
+        <div className="rounded-xl bg-rose-50 dark:bg-rose-950/30 border border-rose-200 dark:border-rose-800 p-3 text-sm text-rose-800 dark:text-rose-200">
+          {retryError}
+        </div>
+      )}
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex-1 rounded-xl bg-stone-100 dark:bg-gray-800 px-4 py-3 text-sm font-semibold text-stone-700 dark:text-stone-200"
+        >
+          Close
+        </button>
+        <button
+          type="button"
+          onClick={handleRetry}
+          disabled={retrying}
+          className="flex-1 rounded-xl bg-amber-500 px-4 py-3 text-sm font-semibold text-white disabled:opacity-60"
+        >
+          {retrying ? "Retrying…" : "Try again"}
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Follow-up to #178. Once Cloudflare reports a verification error (e.g. \"custom hostname does not CNAME to this zone.\"), the cron stopped polling and the user had no in-app way to recover after fixing their DNS. This PR adds:

- **`clearHostnameErrors`** internal mutation (`convex/siteInternals.ts`) — patches \`verificationErrors: []\` and bumps timestamps.
- **`retryCustomHostname`** action (`convex/siteActions.ts`) — verifies ownership, clears the row's errors so the cron picks it back up, and schedules an immediate poll for fast feedback.
- **Retry button** on the `FailedPanel` (`ConnectDomainModal.tsx`) — calls the action and shows a \"Retrying…\" state.

## Test plan

- [x] `npx tsc -b` clean
- [x] `node --test scripts/cloudflare.test.mjs scripts/sites.test.mjs` — 7/7 pass
- [ ] Add CNAME for a test domain → click \"Try again\" on a previously-failed row → modal walks pending_dns → pending_ssl → active

🤖 Generated with [Claude Code](https://claude.com/claude-code)