### PR TITLE
Read X-Original-Host so SaaS custom hostnames route via boop.ad origin

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -28,6 +28,13 @@ function configuredAppHostnames(): Set<string> {
 const appHostnames = configuredAppHostnames();
 
 function hostnameFromRequest(request: Request): string {
+  // Cloudflare for SaaS proxies customer-domain traffic to the boop.ad
+  // Railway origin. Railway routes by Host header, so a Cloudflare Origin
+  // Rule rewrites Host -> boop.ad and a Transform Rule preserves the
+  // original customer hostname in X-Original-Host. Prefer that header so
+  // we know which hosted site to serve.
+  const original = request.headers.get("x-original-host");
+  if (original) return original.split(":")[0].toLowerCase();
   const host = request.headers.get("host") || "";
   return host.split(":")[0].toLowerCase();
 }


### PR DESCRIPTION
## Summary

Last piece of the Cloudflare-for-SaaS path. With #178 + #179 deployed, traffic now flows: customer domain → CF edge → CF proxies to `boop.ad` (Railway) → `server.ts`. But Railway routes by Host header, and only knows `boop.ad` / `www.boop.ad`. Customer-domain traffic with `Host: 21e8.club` was 404'd by Railway's edge before reaching our service ("The train has not arrived at the station").

The canonical SaaS pattern is to **rewrite Host at Cloudflare's edge** to a value Railway recognises, and **preserve the original customer hostname in `X-Original-Host`**.

This PR is the server-side half of that.

## Manual Cloudflare config required (paired with this code change)

On the `boop.ad` zone:

**Transform Rule — Modify Request Header**
- Match: `(not http.host eq "boop.ad" and not http.host eq "www.boop.ad")`
- Action: Set static header `X-Original-Host` = `http.host` (dynamic field)

**Origin Rule — Override Host Header**
- Same match condition
- Action: Override Host Header → `boop.ad`

## Test plan

- [x] `npx tsc -b` clean
- [ ] After merge + Railway deploy + Cloudflare rules: `21e8.club` loads the hosted site instead of Railway's 404
- [ ] `boop.ad` and `www.boop.ad` continue to serve the React app (rules don't match these hostnames)

🤖 Generated with [Claude Code](https://claude.com/claude-code)