### PR TITLE
Replace HTML flow for boop sites

### DIFF
--- a/convex/siteActions.ts
+++ b/convex/siteActions.ts
@@ -527,6 +527,62 @@ export const pollPendingCustomHostnames = internalAction({
   },
 });
 
+const MAX_REPLACE_HTML_BYTES = 2 * 1024 * 1024; // 2 MB
+
+export const replaceSiteFile = action({
+  args: {
+    ownerDid: v.string(),
+    siteId: v.id("sites"),
+    storageId: v.id("_storage"),
+  },
+  handler: async (ctx, args): Promise<{ fileId: string }> => {
+    // Ownership check via the existing query.
+    const owned = await ctx.runQuery(internal.siteInternals.getSiteIdentityForUpdate, {
+      siteId: args.siteId,
+      ownerDid: args.ownerDid,
+    });
+    if (!owned) throw new Error("Site not found");
+
+    const url = await ctx.storage.getUrl(args.storageId);
+    if (!url) throw new Error("Uploaded file not found.");
+
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error("Could not read the uploaded file.");
+    }
+    const buffer = await response.arrayBuffer();
+    const byteLength = buffer.byteLength;
+    if (byteLength === 0) {
+      throw new Error("The uploaded file was empty.");
+    }
+    if (byteLength > MAX_REPLACE_HTML_BYTES) {
+      throw new Error("That file is bigger than the 2 MB limit.");
+    }
+
+    const contentType =
+      response.headers.get("content-type") ?? "text/html; charset=utf-8";
+
+    // SHA-256 hex
+    const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+    const sha256 = Array.from(new Uint8Array(hashBuffer))
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+
+    const result: { fileId: string } = await ctx.runMutation(
+      internal.siteInternals.replaceSiteFileRecord,
+      {
+        siteId: args.siteId,
+        storageId: args.storageId,
+        contentType,
+        sha256,
+        byteLength,
+        now: Date.now(),
+      }
+    );
+    return result;
+  },
+});
+
 export const retryCustomHostname = action({
   args: {
     ownerDid: v.string(),

--- a/convex/siteInternals.ts
+++ b/convex/siteInternals.ts
@@ -332,3 +332,33 @@ export const clearHostnameErrors = internalMutation({
     });
   },
 });
+
+export const replaceSiteFileRecord = internalMutation({
+  args: {
+    siteId: v.id("sites"),
+    storageId: v.id("_storage"),
+    contentType: v.string(),
+    sha256: v.string(),
+    byteLength: v.number(),
+    now: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const site = await ctx.db.get(args.siteId);
+    if (!site) throw new Error("Site not found");
+
+    const newFileId = await ctx.db.insert("siteFiles", {
+      storageId: args.storageId,
+      contentType: args.contentType,
+      sha256: args.sha256,
+      byteLength: args.byteLength,
+      createdAt: args.now,
+    });
+
+    await ctx.db.patch(args.siteId, {
+      fileId: newFileId,
+      updatedAt: args.now,
+    });
+
+    return { fileId: newFileId };
+  },
+});

--- a/src/pages/SiteDetail.tsx
+++ b/src/pages/SiteDetail.tsx
@@ -1,18 +1,24 @@
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
-import { useQuery } from "convex/react";
+import { useAction, useMutation, useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import type { Id } from "../../convex/_generated/dataModel";
 import { useCurrentUser } from "../hooks/useCurrentUser";
 import { useToast } from "../hooks/useToast";
+import { useSettings } from "../hooks/useSettings";
 import { ConnectDomainModal } from "../components/sites/ConnectDomainModal";
 
 export function SiteDetail() {
   const { siteId } = useParams();
   const { did } = useCurrentUser();
   const { addToast } = useToast();
+  const { haptic } = useSettings();
   const [showDomainModal, setShowDomainModal] = useState(false);
   const [showIdentity, setShowIdentity] = useState(false);
+  const generateUploadUrl = useMutation(api.sites.generateSiteUploadUrl);
+  const replaceSiteFile = useAction(api.siteActions.replaceSiteFile);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [replacing, setReplacing] = useState(false);
 
   const site = useQuery(
     api.sites.getSite,
@@ -27,6 +33,39 @@ export function SiteDetail() {
     if (!url) return;
     await navigator.clipboard.writeText(url);
     addToast("Copied your link.");
+  };
+
+  const handleReplaceFile = async (file: File) => {
+    if (!did || !site) return;
+    if (!file.name.toLowerCase().endsWith(".html") && file.type !== "text/html") {
+      addToast("Pick an .html file.", "error");
+      haptic("error");
+      return;
+    }
+    setReplacing(true);
+    haptic("medium");
+    try {
+      const uploadUrl = await generateUploadUrl({ ownerDid: did });
+      const uploadResponse = await fetch(uploadUrl, {
+        method: "POST",
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+        body: file,
+      });
+      if (!uploadResponse.ok) {
+        throw new Error("The file upload did not land. Try again.");
+      }
+      const { storageId } = await uploadResponse.json();
+      await replaceSiteFile({ ownerDid: did, siteId: site._id, storageId });
+      addToast("Site updated.");
+      haptic("success");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Could not update the site.";
+      addToast(message, "error");
+      haptic("error");
+    } finally {
+      setReplacing(false);
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    }
   };
 
   if (site === undefined) {
@@ -66,6 +105,23 @@ export function SiteDetail() {
           >
             Copy
           </button>
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            disabled={replacing}
+            className="rounded-xl bg-stone-100 dark:bg-gray-800 px-4 py-2 text-sm font-semibold text-stone-700 dark:text-stone-200 disabled:opacity-60"
+          >
+            {replacing ? "Replacing…" : "Replace HTML"}
+          </button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="text/html,.html,.htm"
+            className="hidden"
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) handleReplaceFile(file);
+            }}
+          />
           <button
             onClick={() => setShowDomainModal(true)}
             className="rounded-xl bg-amber-500 px-4 py-2 text-sm font-semibold text-white"


### PR DESCRIPTION
## Summary

New "Replace HTML" button on the site detail page. User picks a new `.html` file → it uploads to storage → site's `fileId` flips to point at the new file → next request to the hosted hostname serves the new HTML.

- New action `replaceSiteFile` (`convex/siteActions.ts`) — validates ownership, fetches the upload to compute sha256 + size, calls the internal mutation.
- New internal mutation `replaceSiteFileRecord` (`convex/siteInternals.ts`) — inserts a fresh `siteFiles` row and patches the site's `fileId`. Old `siteFiles` row stays in place (orphaned, harmless) — version history will land properly when this becomes a real Originals DID update.
- UI: hidden `<input type="file">` driven by a "Replace HTML" button next to "Connect a domain you own" on `SiteDetail.tsx`. Reuses the existing `generateSiteUploadUrl` mutation.

The DID log is intentionally untouched — same SCID, same key, same DID. Only the file changes. Real Originals update flow follows later.

## Test plan

- [x] `npx tsc -b` clean
- [ ] Open a hosted site → "Replace HTML" → upload a new file → curl the hostname returns the new HTML
- [ ] Old DID log stays intact (no migration entry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)