### PR TITLE
Authorize DID re-mint with the JWT, not key continuity

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -21,7 +21,7 @@ import {
   removeItem,
   reorderItems,
 } from "./itemsHttp";
-import { updateUserDID } from "./userHttp";
+import { updateUserDID, remintUserDID } from "./userHttp";
 import { storeDidLog, getDidLog } from "./didLogsHttp";
 import { didResourceHandler } from "./didResourcesHttp";
 import { assignItem as assignItemHttp, unassignItem as unassignItemHttp, getItemAssignees as getItemAssigneesHttp } from "./assigneesHttp";
@@ -370,6 +370,8 @@ http.route({ path: "/api/items/reorder", method: "OPTIONS", handler: corsHandler
 
 // --- User endpoints ---
 http.route({ path: "/api/user/updateDID", method: "POST", handler: updateUserDID });
+http.route({ path: "/api/user/remintDid", method: "POST", handler: remintUserDID });
+http.route({ path: "/api/user/remintDid", method: "OPTIONS", handler: corsHandler });
 http.route({ path: "/api/user/updateDID", method: "OPTIONS", handler: corsHandler });
 
 // --- DID log endpoints ---

--- a/convex/migrations/remintUserDidDb.ts
+++ b/convex/migrations/remintUserDidDb.ts
@@ -116,6 +116,18 @@ export const findUserByEmail = internalQuery({
   },
 });
 
+/** Resolves the account from a JWT-verified Turnkey sub-org, never from a body field. */
+export const findUserBySubOrg = internalQuery({
+  args: { turnkeySubOrgId: v.string() },
+  handler: async (ctx, args) => {
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_turnkey_id", (q) => q.eq("turnkeySubOrgId", args.turnkeySubOrgId))
+      .first();
+    return user ? { _id: user._id, did: user.did ?? null, email: user.email } : null;
+  },
+});
+
 export const findUserByDid = internalQuery({
   args: { did: v.string() },
   handler: async (ctx, args) => {

--- a/convex/userHttp.ts
+++ b/convex/userHttp.ts
@@ -5,7 +5,7 @@
  */
 
 import { httpAction } from "./_generated/server";
-import { api } from "./_generated/api";
+import { api, internal } from "./_generated/api";
 import {
   requireAuth,
   AuthError,
@@ -64,6 +64,81 @@ export const updateUserDID = httpAction(async (ctx, request) => {
     return errorResponse(
       request,
       err instanceof Error ? err.message : "Failed to update DID",
+      500
+    );
+  }
+});
+
+/**
+ * POST /api/user/remintDid
+ *
+ * Point the authenticated user at a freshly minted DID and move every row that
+ * referenced the old one.
+ *
+ * Authorized by the JWT, not by key continuity. An earlier design required the
+ * new DID log to be signed by the key controlling the old DID; that is
+ * unsatisfiable for an identity whose original controller key was lost with the
+ * origin it was minted on — didwebvh-ts rejects those with "Key ... is not
+ * authorized to update". The JWT proves account ownership, which is the right
+ * authorization for "reassign my own rows to my own new identifier".
+ *
+ * Strictly safer than the status quo: /api/user/updateDID already lets an
+ * authenticated user change their DID, and today that silently strands every
+ * row on the old value.
+ *
+ * Request: { "did": "did:webvh:...", "didLog": "<jsonl>", "path": "user-..." }
+ * Response: { "success": true, "newDid": "...", "rewritten": n }
+ */
+export const remintUserDID = httpAction(async (ctx, request) => {
+  try {
+    const auth = await requireAuth(request);
+    const body = await request.json();
+    const { did: newDid, didLog, path } = body as {
+      did: string;
+      didLog?: string;
+      path?: string;
+    };
+
+    if (!newDid || !newDid.startsWith("did:webvh:")) {
+      return errorResponse(request, "did must be a did:webvh");
+    }
+
+    // The identity comes from the verified token, never the request body.
+    const user = await ctx.runQuery(internal.migrations.remintUserDidDb.findUserBySubOrg, {
+      turnkeySubOrgId: auth.turnkeySubOrgId,
+    });
+    if (!user || !user.did) {
+      return errorResponse(request, "No DID on the authenticated account");
+    }
+    if (user.did === newDid) {
+      return jsonResponse(request, { success: true, newDid, rewritten: 0 });
+    }
+
+    const { rewritten } = await ctx.runMutation(
+      internal.migrations.remintUserDidDb.applyRemint,
+      { userId: user._id, oldDid: user.did, newDid }
+    );
+
+    if (didLog && path) {
+      await ctx.runMutation(internal.migrations.remintUserDidDb.storeDidLog, {
+        userDid: newDid,
+        path,
+        log: didLog,
+      });
+    }
+
+    console.log(
+      `[userHttp] Re-minted ${auth.email}: ${user.did} -> ${newDid} (${rewritten} rows)`
+    );
+    return jsonResponse(request, { success: true, newDid, rewritten });
+  } catch (err) {
+    if (err instanceof AuthError) {
+      return unauthorizedResponseWithCors(request, err.message);
+    }
+    console.error("[userHttp] Re-mint error:", err);
+    return errorResponse(
+      request,
+      err instanceof Error ? err.message : "Failed to re-mint DID",
       500
     );
   }

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -28,6 +28,7 @@ import {
 } from "react";
 import { createUserWebVHDid } from "../lib/webvh";
 import { useDidDomainRemint } from "./useDidDomainRemint";
+import { getConvexHttpUrl } from "../lib/convexUrls";
 import { storageAdapter } from "../lib/storageAdapter";
 import { identifyUser, resetAnalytics } from "../lib/analytics";
 
@@ -37,17 +38,6 @@ import { identifyUser, resetAnalytics } from "../lib/analytics";
  * Convex Cloud: https://xxx.convex.cloud -> https://xxx.convex.site
  * Local dev: http://127.0.0.1:3210 -> http://127.0.0.1:3211
  */
-function getConvexHttpUrl(): string {
-  const convexUrl = import.meta.env.VITE_CONVEX_URL as string;
-
-  // Local development
-  if (convexUrl.includes("127.0.0.1") || convexUrl.includes("localhost")) {
-    return convexUrl.replace(":3210", ":3211");
-  }
-
-  // Convex cloud deployment
-  return convexUrl.replace(".convex.cloud", ".convex.site");
-}
 
 const JWT_STORAGE_KEY = "lisa-jwt-token";
 
@@ -404,7 +394,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, []);
 
   // Repairs identities minted on a domain we no longer serve. Temporary.
-  useDidDomainRemint(user);
+  useDidDomainRemint(user, token);
 
   const value: AuthContextValue = {
     isAuthenticated: user !== null,

--- a/src/hooks/useDidDomainRemint.ts
+++ b/src/hooks/useDidDomainRemint.ts
@@ -3,62 +3,76 @@
  *
  * A did:webvh encodes its domain in the identifier and ours are non-portable,
  * so an identity minted while the app lived on an old host names that host
- * forever — and since a did:webvh resolves by fetching did.jsonl from its own
- * domain, those DIDs are unresolvable and every list published under them fails
- * to verify.
+ * forever — and a did:webvh resolves by fetching did.jsonl from its own domain,
+ * so those DIDs are unresolvable and lists published under them cannot verify.
  *
- * The mint must happen here, not on the server: the controller key lives in this
- * browser's localStorage and nowhere else. The same key is reused, so the new
- * DID has the same controller — that is also what authorizes the server swap.
+ * The DID is minted here because that is where the signing key lives. It is a
+ * genuinely NEW identity, not a continuation: the key that controlled the old
+ * DID is gone with the origin it was minted on, which is why didwebvh-ts
+ * rejects any attempt to update the old log ("Key ... is not authorized to
+ * update"). There is no continuity left to preserve.
  *
- * TEMPORARY. Delete once no account reports a stale domain; it is a repair pass,
- * not a permanent compatibility layer.
+ * The server authorizes the swap on the JWT, so the rewrite is bounded to the
+ * caller's own account.
+ *
+ * TEMPORARY. Delete once no account reports a stale domain.
  */
 
 import { useEffect, useRef } from "react";
-import { useAction } from "convex/react";
-import { api } from "../../convex/_generated/api";
 import { createUserWebVHDid, isStaleDidDomain } from "../lib/webvh";
+import { getConvexHttpUrl } from "../lib/convexUrls";
 import { Sentry } from "../lib/sentry";
 
-export function useDidDomainRemint(user: {
-  did?: string;
-  email?: string;
-  turnkeySubOrgId?: string;
-} | null) {
-  const remint = useAction(api.remintDid.remintUserDid);
-  // Guards against a second run while the first is in flight — the effect
-  // re-fires as `user` identity changes across renders.
+export function useDidDomainRemint(
+  user: { did?: string; email?: string; turnkeySubOrgId?: string } | null,
+  token: string | null
+) {
+  // Guards a second run while the first is in flight — the effect re-fires as
+  // the user identity changes across renders.
   const attempted = useRef<string | null>(null);
 
   useEffect(() => {
     const did = user?.did;
     const email = user?.email;
     const subOrgId = user?.turnkeySubOrgId;
-    if (!did || !email || !subOrgId) return;
+    if (!did || !email || !subOrgId || !token) return;
     if (!isStaleDidDomain(did)) return;
     if (attempted.current === did) return;
     attempted.current = did;
 
     void (async () => {
       try {
-        // Same localStorage key, current domain — only the domain and SCID move.
         const minted = await createUserWebVHDid({ email, subOrgId });
-        const result = await remint({
-          oldDid: did,
-          newDidLog: minted.didLogJsonl,
-          path: minted.path,
+
+        const response = await fetch(`${getConvexHttpUrl()}/api/user/remintDid`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          credentials: "include",
+          body: JSON.stringify({
+            did: minted.did,
+            didLog: minted.didLogJsonl,
+            path: minted.path,
+          }),
         });
-        if ("newDid" in result) {
-          console.info(`[remint] ${did} -> ${result.newDid} (${result.rewritten} rows)`);
+        if (!response.ok) {
+          throw new Error(`remint failed: ${response.status} ${await response.text()}`);
         }
+
+        const result = (await response.json()) as { newDid: string; rewritten: number };
+        console.info(`[remint] ${did} -> ${result.newDid} (${result.rewritten} rows)`);
+        // The whole app is keyed by DID; reload so every subscription re-reads
+        // under the new identity rather than holding stale rows.
+        window.location.reload();
       } catch (err) {
-        // Never block login on this. The old DID keeps working as an identifier;
+        // Never block login on this. The old DID keeps working as an identifier,
         // it just stays unresolvable until a later attempt succeeds.
         console.error("[remint] failed", err);
         Sentry.captureException(err);
         attempted.current = null;
       }
     })();
-  }, [user?.did, user?.email, user?.turnkeySubOrgId, remint]);
+  }, [user?.did, user?.email, user?.turnkeySubOrgId, token]);
 }

--- a/src/lib/convexUrls.ts
+++ b/src/lib/convexUrls.ts
@@ -1,0 +1,18 @@
+/**
+ * Convex HTTP-action base URL.
+ *
+ * Convex serves functions on .convex.cloud and HTTP actions on .convex.site
+ * (locally, :3210 and :3211). Extracted from useAuth so other modules can call
+ * HTTP endpoints without importing the auth provider and creating a cycle.
+ */
+export function getConvexHttpUrl(): string {
+  const convexUrl = import.meta.env.VITE_CONVEX_URL as string;
+
+  // Local development
+  if (convexUrl.includes("127.0.0.1") || convexUrl.includes("localhost")) {
+    return convexUrl.replace(":3210", ":3211");
+  }
+
+  // Convex cloud deployment
+  return convexUrl.replace(".convex.cloud", ".convex.site");
+}


### PR DESCRIPTION
Follow-up to #216. Signing in on prod produced the error that invalidates its design:

```
Key did:key:z6MktvNdMfyjcW6eFDgALRK2cYbdEU9uxqRxLxBy65mRuXah
is not authorized to update.
```

## Why #216 could never work

didwebvh-ts raises that when a log's proof key isn't in its `updateKeys`. The browser's current `localStorage` key is **not** the key that minted the existing DID — `localStorage` is per-origin, and the original controller key went with the origin the DID was minted on.

#216 required the new log's update keys to intersect the old log's. That's unsatisfiable for exactly the identities this is meant to repair. The hook failed client-side before ever reaching Convex, which is why prod logs showed no invocation at all.

**There is no key continuity left to preserve.** So the re-mint stops pretending to be a continuation and issues a genuinely new identity.

## The new authorization

`POST /api/user/remintDid` calls `requireAuth()`, takes the account from the **verified token**, and rewrites only that account's rows. The request body cannot name a victim — it supplies the new DID, never the identity.

This is **stricter than the status quo, not a relaxation**: `/api/user/updateDID` already lets an authenticated user set their DID to anything, and today that silently strands every row on the old value. Pairing the swap with `applyRemint` closes that gap.

`applyRemint` — the 17-table/24-field rewrite with 8 tests — is unchanged. It never cared where the new DID came from.

## Also

- Extracts `getConvexHttpUrl` into `lib/convexUrls` so the hook can reach HTTP actions without importing the auth provider, which imports the hook.
- The client reloads after a successful re-mint. The app is keyed by DID throughout, so live subscriptions would otherwise keep reading rows under the old identity.

## What this costs

The new DID has **no cryptographic link** to the old one — it's a fresh identity that inherits the account's data. Given the old key is unrecoverable, the alternative isn't "preserve continuity", it's "stay broken". Old `trypoo.app` URLs stay dead either way, and `did:cel` envelopes still record the original creator DID in signed content.

Suite 114 pass / 0 fail; both typechecks clean; lint unchanged from baseline.

## After merge

Sign in on web. Expect a `[remint]` line in the console, a reload, then:
```
npx convex run --prod migrations/remintUserDidDb:listUsersOnDomain '{"domain":"trypoo.app"}'
```
should drop by one per account signed in, draining to `[]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Authorize DID re-mint via JWT instead of key continuity in `remintUserDID`
> - Adds a new authenticated `POST /api/user/remintDid` HTTP endpoint ([convex/userHttp.ts](https://github.com/aviarytech/todo/pull/217/files#diff-365ba550e65f281a25f7358b8172e57bce162e67c213ccfc5b2271dbfbc4613a)) that reassigns all rows from a user's current DID to a newly minted `did:webvh`, authorizing via JWT rather than trusting any user ID in the request body.
> - The endpoint resolves the caller's account by `turnkeySubOrgId` from the JWT using a new internal query `findUserBySubOrg` ([convex/migrations/remintUserDidDb.ts](https://github.com/aviarytech/todo/pull/217/files#diff-b09a864b2fdb26ccef4b71c3de5485b4617e50ab8846a3a790e8eeac2813a6ca)), optionally persisting a DID log when `didLog` and `path` are provided.
> - Refactors [src/hooks/useDidDomainRemint.ts](https://github.com/aviarytech/todo/pull/217/files#diff-f9d719f82fe4d336ff534de81a9803af259286db61d727845e8b71f9fc97f925) to accept a JWT token and call the new HTTP endpoint directly via `fetch` with `Authorization: Bearer`, replacing the previous Convex action invocation; forces a full page reload on success.
> - Extracts `getConvexHttpUrl` into a shared [src/lib/convexUrls.ts](https://github.com/aviarytech/todo/pull/217/files#diff-a2cb80673e1577799deac2f936309579c6a0e04284c60731041c2af19b2a3eee) utility to avoid cyclic imports.
> - Behavioral Change: the repair pass now requires a valid JWT token to run; remint attempts will short-circuit until the token is available.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b43dc87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->