### PR TITLE
/auth/verify never returned the stored DID, so every login minted a throwaway one

### DIFF
--- a/convex/http.ts
+++ b/convex/http.ts
@@ -238,16 +238,24 @@ const verify = httpAction(async (ctx, request) => {
       subOrgId: result.subOrgId,
     });
 
-    // DID creation happens client-side after auth completes.
-    // Server stores user without a DID; client creates did:webvh
-    // using BrowserWebVHSigner and calls /api/user/updateDID.
-
-    // Create/update user (no DID yet — client will create did:webvh and call /api/user/updateDID)
+    // DID creation happens client-side after auth completes: for a NEW account
+    // the client mints a did:webvh with BrowserWebVHSigner and posts it to
+    // /api/user/updateDID.
     await ctx.runMutation(api.auth.upsertUser, {
       turnkeySubOrgId: result.subOrgId,
       email: result.email,
       did: undefined,
       displayName: result.email.split("@")[0],
+    });
+
+    // Return the DID we actually hold. This used to be hardcoded null, so every
+    // login looked like a first login: the client minted a fresh did:webvh and
+    // posted it, upsertUser silently refused to overwrite an existing one, and
+    // the client then treated the discarded DID as its identity. That burned a
+    // keypair per login and, worse, left the client's DID disagreeing with the
+    // database — which is why the stale-domain re-mint never fired.
+    const storedUser = await ctx.runQuery(api.auth.getUserByTurnkeyId, {
+      turnkeySubOrgId: result.subOrgId,
     });
 
     // Get JWT token via internal action
@@ -267,8 +275,8 @@ const verify = httpAction(async (ctx, request) => {
         user: {
           turnkeySubOrgId: result.subOrgId,
           email: result.email,
-          did: null,
-          displayName: result.email.split("@")[0],
+          did: storedUser?.did ?? null,
+          displayName: storedUser?.displayName ?? result.email.split("@")[0],
         },
       },
       200,

--- a/convex/userHttp.ts
+++ b/convex/userHttp.ts
@@ -13,6 +13,17 @@ import {
 } from "./lib/auth";
 import { jsonResponse, errorResponse } from "./lib/httpResponses";
 
+/** The domain encoded in a did:webvh, percent-decoded. Null if not a did:webvh. */
+function didWebvhDomain(did: string): string | null {
+  const parts = did.split(":");
+  if (parts.length < 5 || parts[1] !== "webvh") return null;
+  try {
+    return decodeURIComponent(parts[3]);
+  } catch {
+    return parts[3];
+  }
+}
+
 /**
  * POST /api/user/updateDID
  *
@@ -112,6 +123,20 @@ export const remintUserDID = httpAction(async (ctx, request) => {
     }
     if (user.did === newDid) {
       return jsonResponse(request, { success: true, newDid, rewritten: 0 });
+    }
+
+    // Only ever repair an identity that is actually on a stale domain. Without
+    // this, a client whose cached auth state still holds the pre-migration DID
+    // re-triggers on every reload and walks the account to a new DID each time.
+    const targetDomain = process.env.WEBVH_DOMAIN;
+    const currentDomain = didWebvhDomain(user.did);
+    if (targetDomain && currentDomain === targetDomain) {
+      return jsonResponse(request, {
+        success: true,
+        newDid: user.did,
+        rewritten: 0,
+        skipped: "already on the current domain",
+      });
     }
 
     const { rewritten } = await ctx.runMutation(

--- a/src/hooks/useDidDomainRemint.ts
+++ b/src/hooks/useDidDomainRemint.ts
@@ -21,7 +21,11 @@
 import { useEffect, useRef } from "react";
 import { createUserWebVHDid, isStaleDidDomain } from "../lib/webvh";
 import { getConvexHttpUrl } from "../lib/convexUrls";
+import { storageAdapter } from "../lib/storageAdapter";
 import { Sentry } from "../lib/sentry";
+
+/** Must match useAuth's persisted-state key. */
+const AUTH_STORAGE_KEY = "lisa-auth-state";
 
 export function useDidDomainRemint(
   user: { did?: string; email?: string; turnkeySubOrgId?: string } | null,
@@ -63,6 +67,24 @@ export function useDidDomainRemint(
 
         const result = (await response.json()) as { newDid: string; rewritten: number };
         console.info(`[remint] ${did} -> ${result.newDid} (${result.rewritten} rows)`);
+
+        // Persisted auth state is restored on reload without re-contacting the
+        // server, so leaving the old DID cached would re-trigger this on every
+        // load. (The endpoint also refuses a second migration, but burning a
+        // keypair per reload is worth avoiding.)
+        try {
+          const raw = await storageAdapter.get(AUTH_STORAGE_KEY);
+          if (raw) {
+            const state = JSON.parse(raw);
+            if (state?.user) {
+              state.user.did = result.newDid;
+              await storageAdapter.set(AUTH_STORAGE_KEY, JSON.stringify(state));
+            }
+          }
+        } catch (cacheErr) {
+          console.warn("[remint] could not refresh cached auth state", cacheErr);
+        }
+
         // The whole app is keyed by DID; reload so every subscription re-reads
         // under the new identity rather than holding stale rows.
         window.location.reload();


### PR DESCRIPTION
This is why the re-mint still didn't run after #218.

## The bug

`/auth/verify` hardcoded `did: null` in its response and never read the DID it already held. So **every** login looked like a first login:

1. Client sees `did: null` → falls back to `did:temp:{subOrgId}`
2. Client mints a **brand-new** `did:webvh` and POSTs `/api/user/updateDID`
3. `upsertUser` refuses to overwrite an existing `did:webvh` ([auth.ts:41](../blob/main/convex/auth.ts#L41)) → **silent no-op**, while the endpoint still logs `"DID updated successfully"`
4. Client keeps the discarded DID as its in-memory identity

Two consequences. A fresh keypair was minted and thrown away **on every single login**. And the client's DID silently disagreed with the database.

That second one is what defeated the re-mint: by the time the hook ran, the client believed it was already on `boop.ad`, so `isStaleDidDomain` returned false and it skipped — while `users.did` was still the `trypoo.app` DID with every row attached to it.

## Confirmed on prod

After a sign-in, logs showed:
```
[userHttp] Updating DID for brian@aviary.tech to did:webvh:QmZudwPv…:boop.ad:user-20ed9d43-2d31-44
[userHttp] DID updated successfully for brian@aviary.tech
```
while `findUserByEmail` still returned the `trypoo.app` DID and `previewRemint` still counted every row against it — 344 items, 18 lists, 7 sites, 7 publications, 2 categories, 1 bookmark.

## Fix

Return the stored `did` (and `displayName`). An existing user is recognised and the client stops minting. A genuinely new account still has no DID and takes the mint path unchanged.

## Loop guard

With the DID now reported correctly, the hook fires — which exposes a second problem. Persisted auth state is restored on reload **without** contacting the server, so a cached pre-migration DID would re-trigger the hook every load and walk the account to a new DID each time.

Two independent defences:
- **Server:** the endpoint refuses to migrate an identity already on `WEBVH_DOMAIN`. This holds regardless of client state.
- **Client:** the hook refreshes cached auth state before reloading, so it doesn't burn a keypair per reload.

116 pass / 0 fail; both typechecks clean; lint clean on touched files.

## After merge

Wait for **Railway**, not just Deploy Convex. Then sign in once per account. `users.did` should move and `previewRemint` against the old DID should drop to `{}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `/auth/verify` to return the stored DID instead of always minting a new one
> - [`convex/http.ts`](https://github.com/aviarytech/todo/pull/219/files#diff-22ae6ac3563719a97f99af3980d10844cb0544e14f25f6c2ca41155c4c86eea5): After verifying a session, the handler now fetches the user by `turnkeySubOrgId` and returns the stored `did` and `displayName` instead of always returning `null` and the email-derived display name.
> - [`convex/userHttp.ts`](https://github.com/aviarytech/todo/pull/219/files#diff-365ba550e65f281a25f7358b8172e57bce162e67c213ccfc5b2271dbfbc4613a): `POST /api/user/remintDid` skips reminting when the user's existing `did:webvh` domain already matches `WEBVH_DOMAIN`, returning the current DID with a `skipped` reason.
> - [`src/hooks/useDidDomainRemint.ts`](https://github.com/aviarytech/todo/pull/219/files#diff-f9d719f82fe4d336ff534de81a9803af259286db61d727845e8b71f9fc97f925): After a successful remint, the hook updates the persisted auth state in storage with the new DID before reloading the page.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78f3d1a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->