### PR TITLE
New categories saved but rendered nowhere

### DIFF
--- a/convex/lib/itemCategories.ts
+++ b/convex/lib/itemCategories.ts
@@ -51,6 +51,19 @@ export const DEFAULT_CATEGORIES: Category[] = [
   { id: "other", name: "Other", emoji: "🛒", order: 99 },
 ];
 
+/**
+ * True for a built-in category the user has never touched.
+ *
+ * Drives visibility: an untouched default is hidden while empty (so a short
+ * grocery list is not buried under 15 unused aisle headers), but anything the
+ * user added, renamed or re-emoji'd stays visible even with no items — you
+ * cannot drag an item into a category you cannot see.
+ */
+export function isPristineDefault(category: Category): boolean {
+  const original = DEFAULT_CATEGORIES.find((d) => d.id === category.id);
+  return !!original && original.name === category.name && original.emoji === category.emoji;
+}
+
 /** True once a list owns its categories and should not be offered grocery aisles. */
 export function hasOwnCategories(categories: Category[] | undefined | null): boolean {
   return Array.isArray(categories) && categories.length > 0;

--- a/scripts/categories.test.mjs
+++ b/scripts/categories.test.mjs
@@ -225,9 +225,42 @@ test("groupByCategory returns non-empty groups in display order", () => {
   ]);
 });
 
-test("groupByCategory omits empty categories, including Other", () => {
-  const groups = c.groupByCategory([{ name: "Passport", groceryAisle: "luggage" }], packingSet());
-  assert.deepEqual(groups.map((g) => g.category.id), ["luggage"]);
+test("groupByCategory hides untouched built-ins that are empty", () => {
+  // A short grocery list should not be buried under 15 unused aisle headers.
+  const groups = c.groupByCategory([{ name: "bananas" }], c.resolveCategories(undefined));
+  assert.deepEqual(groups.map((g) => g.category.id), ["produce"]);
+});
+
+test("a user-created category stays visible while empty", () => {
+  // The bug this guards: an added category rendered nowhere, so it looked like
+  // it had failed to save — and there was no target to drag items into.
+  const set = c.addCategory(c.materialiseCategories(undefined, []), "Luggage", "\u{1F9F3}");
+  const groups = c.groupByCategory([{ name: "bananas" }], set);
+
+  const ids = groups.map((g) => g.category.id);
+  assert.ok(ids.includes("luggage"), "a category you just made must appear");
+  assert.deepEqual(groups.find((g) => g.category.id === "luggage").items, []);
+  assert.equal(ids.includes("bakery"), false, "untouched empty built-ins stay hidden");
+});
+
+test("a renamed or re-emoji'd built-in stays visible while empty", () => {
+  const renamed = c.renameCategory(c.materialiseCategories(undefined, []), "produce", "Fruit");
+  assert.ok(
+    c.groupByCategory([], renamed).some((g) => g.category.id === "produce"),
+    "renaming signals intent to use it"
+  );
+
+  const re_emoji = c.setCategoryEmoji(c.materialiseCategories(undefined, []), "bakery", "\u{1F950}");
+  assert.ok(c.groupByCategory([], re_emoji).some((g) => g.category.id === "bakery"));
+});
+
+test("every user-made category is visible before anything is filed; empty Other is not", () => {
+  const groups = c.groupByCategory([], packingSet());
+  assert.deepEqual(
+    groups.map((g) => g.category.id),
+    ["luggage", "clothes", "electronics"],
+    "an empty Other bucket is noise — it appears only once something lands in it"
+  );
 });
 
 test("groupByCategory keeps every item exactly once", () => {

--- a/src/lib/categories.ts
+++ b/src/lib/categories.ts
@@ -10,6 +10,7 @@ import { classifyItem } from "./groceryAisles";
 import {
   type Category,
   OTHER_CATEGORY_ID,
+  isPristineDefault,
   resolveCategories,
 } from "../../convex/lib/itemCategories";
 
@@ -40,9 +41,13 @@ export function resolveItemCategory(item: CategorisableItem, categories: Categor
 }
 
 /**
- * Groups items into the list's categories, in display order. Empty categories
- * are dropped so a list is not padded with headers it never uses — except Other,
- * which is also dropped when empty.
+ * Groups items into the list's categories, in display order.
+ *
+ * An empty category is still shown when the user made it theirs — added,
+ * renamed or re-emoji'd. Only untouched built-ins are hidden while empty, so a
+ * short grocery list is not buried under unused aisle headers. Hiding a
+ * user-created category would make it look like it failed to save, and leave no
+ * target to drag items into.
  */
 export function groupByCategory<T extends CategorisableItem>(
   items: T[],
@@ -59,7 +64,10 @@ export function groupByCategory<T extends CategorisableItem>(
   }
 
   return resolved
-    .filter((category) => (buckets.get(category.id)?.length ?? 0) > 0)
-    .map((category) => ({ category, items: buckets.get(category.id)! }));
+    .filter(
+      (category) =>
+        (buckets.get(category.id)?.length ?? 0) > 0 || !isPristineDefault(category)
+    )
+    .map((category) => ({ category, items: buckets.get(category.id) ?? [] }));
 }
 


### PR DESCRIPTION
Adding a category looked like it silently failed. It didn't — it saved and then rendered nowhere.

Verified against prod before changing anything: the list already had both categories stored.

```
itemCategories: 18 saved
    🥬 Produce …
    🏷️ Food (id=food)      ← added, never displayed
    🏷️ test (id=test)      ← added, never displayed
    🛒 Other (id=other)
```

## Cause

`groupByCategory` dropped every category with no items. That was right while categories were implicit — a five-item grocery list shouldn't be buried under 15 unused aisle headers — and wrong the moment users create categories by hand. It also left **no drop target**: you can't drag an item into a category that isn't rendered, so a new category could never receive its first item.

## Fix

Visibility keys off a new `isPristineDefault`: an empty category is hidden **only** when it's a built-in the user has never touched.

| Category | Empty | Shown |
|---|---|---|
| Untouched built-in (Bakery) | yes | no — keeps short lists clean |
| User-added (Luggage) | yes | **yes** |
| Renamed built-in (Produce → Fruit) | yes | **yes** — renaming signals intent |
| Re-emoji'd built-in | yes | **yes** |
| Other | yes | no — noise until something lands in it |

## On how this shipped

The old behaviour had a passing test asserting it (`"groupByCategory omits empty categories, including Other"`). It encoded the previous assumption rather than the requirement, so it locked in the bug instead of catching it. Replaced with cases for an added category, a renamed built-in, and a re-emoji'd built-in.

151 pass / 0 fail. Both typechecks clean; lint unchanged.

## After merge

Wait for Railway, then reload — "Food" and "test" are already in your list and will simply appear. Nothing to re-create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show empty user-created and modified categories that were previously hidden
> - `groupByCategory` in [categories.ts](https://github.com/aviarytech/todo/pull/221/files#diff-c29f13fd6bbcb45a10442d573585c2f8e29b2a8f2c5a5fb1050c8e1f5a81c3e4) previously hid all empty categories; it now hides only empty built-in categories that are untouched (same name and emoji as the default).
> - A new `isPristineDefault` predicate in [itemCategories.ts](https://github.com/aviarytech/todo/pull/221/files#diff-ee80f85ad053530fac2479ed9f42378c634697e756de57ccbc3a8bd4e1545ba7) checks whether a category matches its original built-in definition by id, name, and emoji.
> - User-created categories and renamed or re-emoji'd built-ins are now included in grouped results with an empty `items` array when they have no items.
> - Behavioral Change: empty categories that were previously omitted from results will now appear if the user created or modified them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c62f59d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->